### PR TITLE
fix(wsdl): improve dark mode

### DIFF
--- a/.changeset/heavy-windows-jump.md
+++ b/.changeset/heavy-windows-jump.md
@@ -1,0 +1,6 @@
+---
+'@dweber019/backstage-plugin-api-docs-module-wsdl-backend': patch
+'@dweber019/backstage-plugin-api-docs-module-wsdl': patch
+---
+
+Improve dark mode.

--- a/plugins/api-docs-module-wsdl-backend/src/stylesheet.sef.json
+++ b/plugins/api-docs-module-wsdl-backend/src/stylesheet.sef.json
@@ -7,7 +7,7 @@
   "targetVersion": "2",
   "name": "TOP-LEVEL",
   "relocatable": "false",
-  "buildDateTime": "2023-12-22T00:41:23.384+01:00",
+  "buildDateTime": "2024-03-07T22:10:46.41+01:00",
   "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
   "C": [
     {
@@ -23,7 +23,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}src.syntax-error",
-          "line": "585",
+          "line": "589",
           "expand-text": "false",
           "sType": "0 ",
           "C": [
@@ -88,7 +88,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}src.syntax-error.path",
-          "line": "589",
+          "line": "593",
           "expand-text": "false",
           "sType": "* ",
           "C": [
@@ -100,13 +100,13 @@
                 {
                   "N": "forEach",
                   "sType": "* ",
-                  "line": "590",
+                  "line": "594",
                   "C": [
                     {
                       "N": "docOrder",
                       "sType": "*NE",
                       "role": "select",
-                      "line": "590",
+                      "line": "594",
                       "C": [
                         {
                           "N": "slash",
@@ -136,7 +136,7 @@
                       "bSlot": "0",
                       "sType": "* ",
                       "name": "Q{}src.syntax-error.path",
-                      "line": "591"
+                      "line": "595"
                     }
                   ]
                 },
@@ -144,7 +144,7 @@
                   "N": "valueOf",
                   "flags": "l",
                   "sType": "1NT ",
-                  "line": "593",
+                  "line": "597",
                   "C": [
                     {
                       "N": "fn",
@@ -160,7 +160,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "593",
+                              "line": "597",
                               "C": [
                                 { "N": "str", "val": "/" },
                                 {
@@ -213,7 +213,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}render.source-code-link",
-          "line": "603",
+          "line": "607",
           "expand-text": "false",
           "sType": "? ",
           "C": [
@@ -221,13 +221,13 @@
               "N": "choose",
               "sType": "? ",
               "role": "body",
-              "line": "604",
+              "line": "608",
               "C": [
                 {
                   "N": "and",
                   "sType": "1AB",
                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                  "line": "604",
+                  "line": "608",
                   "C": [
                     {
                       "N": "gVarRef",
@@ -243,7 +243,7 @@
                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                  "line": "605",
+                  "line": "609",
                   "C": [
                     {
                       "N": "sequence",
@@ -288,7 +288,7 @@
                                                   "name": "concat",
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "605",
+                                                  "line": "609",
                                                   "C": [
                                                     { "N": "str", "val": "#" },
                                                     {
@@ -343,7 +343,7 @@
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "606",
+                          "line": "610",
                           "C": [
                             {
                               "N": "fn",
@@ -370,7 +370,7 @@
                                                   "name": "Q{}SOURCE-CODE-TEXT",
                                                   "bSlot": "3",
                                                   "role": "select",
-                                                  "line": "606"
+                                                  "line": "610"
                                                 }
                                               ]
                                             }
@@ -416,7 +416,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}processor-info.render",
-          "line": "610",
+          "line": "614",
           "expand-text": "false",
           "sType": "*N ",
           "C": [
@@ -447,7 +447,7 @@
                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                  "line": "614",
+                  "line": "618",
                   "C": [
                     {
                       "N": "sequence",
@@ -485,7 +485,7 @@
                                                   "name": "system-property",
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "614",
+                                                  "line": "618",
                                                   "C": [
                                                     {
                                                       "N": "str",
@@ -510,7 +510,7 @@
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "615",
+                          "line": "619",
                           "C": [
                             {
                               "N": "fn",
@@ -526,7 +526,7 @@
                                       "sType": "1AS",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "615",
+                                      "line": "619",
                                       "C": [{ "N": "str", "val": "xsl:vendor" }]
                                     }
                                   ]
@@ -562,7 +562,7 @@
                   "N": "valueOf",
                   "flags": "l",
                   "sType": "1NT ",
-                  "line": "621",
+                  "line": "625",
                   "C": [
                     {
                       "N": "fn",
@@ -578,7 +578,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "621",
+                              "line": "625",
                               "C": [
                                 {
                                   "N": "fn",
@@ -629,7 +629,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}recursion.should.continue",
-          "line": "1151",
+          "line": "1155",
           "expand-text": "false",
           "sType": "* ",
           "C": [
@@ -645,7 +645,7 @@
                   "sType": "* ",
                   "as": "* ",
                   "flags": "",
-                  "line": "1152",
+                  "line": "1156",
                   "C": [
                     {
                       "N": "str",
@@ -668,7 +668,7 @@
                   "sType": "* ",
                   "as": "* ",
                   "flags": "",
-                  "line": "1153",
+                  "line": "1157",
                   "C": [
                     {
                       "N": "str",
@@ -691,7 +691,7 @@
                   "sType": "* ",
                   "as": "* ",
                   "flags": "",
-                  "line": "1154",
+                  "line": "1158",
                   "C": [
                     {
                       "N": "doc",
@@ -719,7 +719,7 @@
                   "var": "Q{}has.recursion",
                   "slot": "3",
                   "sType": "* ",
-                  "line": "1155",
+                  "line": "1159",
                   "C": [
                     {
                       "N": "fn",
@@ -727,7 +727,7 @@
                       "sType": "1AB",
                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                       "role": "select",
-                      "line": "1155",
+                      "line": "1159",
                       "C": [
                         {
                           "N": "fn",
@@ -772,7 +772,7 @@
                       "var": "Q{}anti.recursion.fragment",
                       "slot": "4",
                       "sType": "* ",
-                      "line": "1157",
+                      "line": "1161",
                       "C": [
                         {
                           "N": "fn",
@@ -780,7 +780,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1157",
+                          "line": "1161",
                           "C": [
                             {
                               "N": "fn",
@@ -824,7 +824,7 @@
                           "N": "choose",
                           "sType": "* ",
                           "type": "item()*",
-                          "line": "1158",
+                          "line": "1162",
                           "C": [
                             {
                               "N": "gc10",
@@ -833,7 +833,7 @@
                               "card": "1:1",
                               "sType": "1AB",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                              "line": "1159",
+                              "line": "1163",
                               "C": [
                                 {
                                   "N": "varRef",
@@ -852,7 +852,7 @@
                               "N": "or",
                               "sType": "1AB",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                              "line": "1161",
+                              "line": "1165",
                               "C": [
                                 {
                                   "N": "or",
@@ -925,7 +925,7 @@
                               "bSlot": "2",
                               "sType": "* ",
                               "name": "Q{}recursion.should.continue",
-                              "line": "1166",
+                              "line": "1170",
                               "C": [
                                 {
                                   "N": "withParam",
@@ -940,7 +940,7 @@
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1167"
+                                      "line": "1171"
                                     }
                                   ]
                                 },
@@ -957,7 +957,7 @@
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1168"
+                                      "line": "1172"
                                     }
                                   ]
                                 },
@@ -974,7 +974,7 @@
                                       "sType": "?AO",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1169",
+                                      "line": "1173",
                                       "C": [
                                         {
                                           "N": "atomSing",
@@ -1025,7 +1025,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}process-union",
-          "line": "1264",
+          "line": "1268",
           "expand-text": "false",
           "sType": "* ",
           "C": [
@@ -1041,7 +1041,7 @@
                   "sType": "* ",
                   "as": "* ",
                   "flags": "",
-                  "line": "1265",
+                  "line": "1269",
                   "C": [
                     {
                       "N": "str",
@@ -1060,7 +1060,7 @@
                 {
                   "N": "choose",
                   "sType": "* ",
-                  "line": "1266",
+                  "line": "1270",
                   "C": [
                     {
                       "N": "varRef",
@@ -1068,14 +1068,14 @@
                       "slot": "0",
                       "sType": "*",
                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                      "line": "1266"
+                      "line": "1270"
                     },
                     {
                       "N": "let",
                       "var": "Q{}item",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1267",
+                      "line": "1271",
                       "C": [
                         {
                           "N": "fn",
@@ -1083,7 +1083,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1267",
+                          "line": "1271",
                           "C": [
                             {
                               "N": "fn",
@@ -1113,7 +1113,7 @@
                           "var": "Q{}the-rest",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1268",
+                          "line": "1272",
                           "C": [
                             {
                               "N": "fn",
@@ -1121,7 +1121,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1268",
+                              "line": "1272",
                               "C": [
                                 {
                                   "N": "fn",
@@ -1151,7 +1151,7 @@
                               "var": "Q{}type-local-name",
                               "slot": "3",
                               "sType": "* ",
-                              "line": "1270",
+                              "line": "1274",
                               "C": [
                                 {
                                   "N": "fn",
@@ -1159,7 +1159,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1270",
+                                  "line": "1274",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -1189,7 +1189,7 @@
                                   "var": "Q{}type-name",
                                   "slot": "4",
                                   "sType": "* ",
-                                  "line": "1271",
+                                  "line": "1275",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -1201,7 +1201,7 @@
                                           "N": "choose",
                                           "sType": "?NT ",
                                           "type": "item()*",
-                                          "line": "1272",
+                                          "line": "1276",
                                           "C": [
                                             {
                                               "N": "varRef",
@@ -1209,13 +1209,13 @@
                                               "slot": "3",
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1273"
+                                              "line": "1277"
                                             },
                                             {
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1274",
+                                              "line": "1278",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -1243,7 +1243,7 @@
                                                                       "slot": "3",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1274"
+                                                                      "line": "1278"
                                                                     }
                                                                   ]
                                                                 }
@@ -1275,7 +1275,7 @@
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1277",
+                                              "line": "1281",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -1303,7 +1303,7 @@
                                                                       "slot": "1",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1277"
+                                                                      "line": "1281"
                                                                     }
                                                                   ]
                                                                 }
@@ -1343,7 +1343,7 @@
                                           "bSlot": "0",
                                           "sType": "* ",
                                           "name": "Q{}render-type",
-                                          "line": "1282",
+                                          "line": "1286",
                                           "C": [
                                             {
                                               "N": "withParam",
@@ -1358,7 +1358,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1283"
+                                                  "line": "1287"
                                                 }
                                               ]
                                             }
@@ -1369,7 +1369,7 @@
                                           "bSlot": "1",
                                           "sType": "* ",
                                           "name": "Q{}process-union",
-                                          "line": "1286",
+                                          "line": "1290",
                                           "C": [
                                             {
                                               "N": "withParam",
@@ -1384,7 +1384,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1287"
+                                                  "line": "1291"
                                                 }
                                               ]
                                             }
@@ -1423,7 +1423,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}xsd.element-type",
-          "line": "1427",
+          "line": "1431",
           "expand-text": "false",
           "sType": "*NT ",
           "C": [
@@ -1432,7 +1432,7 @@
               "var": "Q{}ref-or-type",
               "slot": "0",
               "sType": "*NT ",
-              "line": "1428",
+              "line": "1432",
               "role": "body",
               "C": [
                 {
@@ -1445,12 +1445,12 @@
                       "N": "choose",
                       "sType": "?NT ",
                       "type": "item()*",
-                      "line": "1429",
+                      "line": "1433",
                       "C": [
                         {
                           "N": "docOrder",
                           "sType": "*NA nQ{}type",
-                          "line": "1430",
+                          "line": "1434",
                           "C": [
                             {
                               "N": "slash",
@@ -1479,7 +1479,7 @@
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "1431",
+                          "line": "1435",
                           "C": [
                             {
                               "N": "fn",
@@ -1504,7 +1504,7 @@
                                                   "N": "docOrder",
                                                   "sType": "*NA nQ{}type",
                                                   "role": "select",
-                                                  "line": "1431",
+                                                  "line": "1435",
                                                   "C": [
                                                     {
                                                       "N": "slash",
@@ -1553,7 +1553,7 @@
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "1434",
+                          "line": "1438",
                           "C": [
                             {
                               "N": "fn",
@@ -1578,7 +1578,7 @@
                                                   "N": "docOrder",
                                                   "sType": "*NA nQ{}ref",
                                                   "role": "select",
-                                                  "line": "1434",
+                                                  "line": "1438",
                                                   "C": [
                                                     {
                                                       "N": "slash",
@@ -1631,7 +1631,7 @@
                   "var": "Q{}type-local-name",
                   "slot": "1",
                   "sType": "*NT ",
-                  "line": "1439",
+                  "line": "1443",
                   "C": [
                     {
                       "N": "fn",
@@ -1639,7 +1639,7 @@
                       "sType": "1AS",
                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                       "role": "select",
-                      "line": "1439",
+                      "line": "1443",
                       "C": [
                         {
                           "N": "fn",
@@ -1669,7 +1669,7 @@
                       "var": "Q{}type-name",
                       "slot": "2",
                       "sType": "*NT ",
-                      "line": "1440",
+                      "line": "1444",
                       "C": [
                         {
                           "N": "doc",
@@ -1681,7 +1681,7 @@
                               "N": "choose",
                               "sType": "?NT ",
                               "type": "item()*",
-                              "line": "1441",
+                              "line": "1445",
                               "C": [
                                 {
                                   "N": "varRef",
@@ -1689,13 +1689,13 @@
                                   "slot": "1",
                                   "sType": "*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1442"
+                                  "line": "1446"
                                 },
                                 {
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "1443",
+                                  "line": "1447",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -1723,7 +1723,7 @@
                                                           "slot": "1",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1443"
+                                                          "line": "1447"
                                                         }
                                                       ]
                                                     }
@@ -1754,13 +1754,13 @@
                                   "slot": "0",
                                   "sType": "*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1445"
+                                  "line": "1449"
                                 },
                                 {
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "1446",
+                                  "line": "1450",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -1788,7 +1788,7 @@
                                                           "slot": "0",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1446"
+                                                          "line": "1450"
                                                         }
                                                       ]
                                                     }
@@ -1833,7 +1833,7 @@
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "1451",
+                          "line": "1455",
                           "C": [
                             {
                               "N": "fn",
@@ -1861,7 +1861,7 @@
                                                   "slot": "2",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1451"
+                                                  "line": "1455"
                                                 }
                                               ]
                                             }
@@ -1905,7 +1905,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}render-type",
-          "line": "1458",
+          "line": "1462",
           "expand-text": "false",
           "sType": "* ",
           "C": [
@@ -1921,7 +1921,7 @@
                   "sType": "* ",
                   "as": "* ",
                   "flags": "",
-                  "line": "1459",
+                  "line": "1463",
                   "C": [
                     {
                       "N": "str",
@@ -1944,7 +1944,7 @@
                   "sType": "* ",
                   "as": "* ",
                   "flags": "",
-                  "line": "1460",
+                  "line": "1464",
                   "C": [
                     {
                       "N": "str",
@@ -1963,21 +1963,21 @@
                 {
                   "N": "choose",
                   "sType": "* ",
-                  "line": "1462",
+                  "line": "1466",
                   "C": [
                     {
                       "N": "gVarRef",
                       "name": "Q{}ENABLE-OPERATIONS-TYPE",
                       "bSlot": "0",
                       "sType": "* ",
-                      "line": "1462"
+                      "line": "1466"
                     },
                     {
                       "N": "let",
                       "var": "Q{}properties",
                       "slot": "2",
                       "sType": "* ",
-                      "line": "1463",
+                      "line": "1467",
                       "C": [
                         {
                           "N": "doc",
@@ -1988,12 +1988,12 @@
                             {
                               "N": "choose",
                               "sType": "* ",
-                              "line": "1464",
+                              "line": "1468",
                               "C": [
                                 {
                                   "N": "docOrder",
                                   "sType": "*NE u[NE nQ{http://www.w3.org/2001/XMLSchema}element,NE nQ{http://www.w3.org/2001/XMLSchema}attribute]",
-                                  "line": "1464",
+                                  "line": "1468",
                                   "C": [
                                     {
                                       "N": "union",
@@ -2030,7 +2030,7 @@
                                   "var": "Q{}min",
                                   "slot": "2",
                                   "sType": "* ",
-                                  "line": "1465",
+                                  "line": "1469",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -2041,7 +2041,7 @@
                                         {
                                           "N": "choose",
                                           "sType": "? ",
-                                          "line": "1466",
+                                          "line": "1470",
                                           "C": [
                                             {
                                               "N": "gc10",
@@ -2050,7 +2050,7 @@
                                               "card": "1:1",
                                               "sType": "1AB",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1466",
+                                              "line": "1470",
                                               "C": [
                                                 {
                                                   "N": "axis",
@@ -2082,7 +2082,7 @@
                                       "var": "Q{}max",
                                       "slot": "3",
                                       "sType": "* ",
-                                      "line": "1468",
+                                      "line": "1472",
                                       "C": [
                                         {
                                           "N": "doc",
@@ -2093,7 +2093,7 @@
                                             {
                                               "N": "choose",
                                               "sType": "? ",
-                                              "line": "1469",
+                                              "line": "1473",
                                               "C": [
                                                 {
                                                   "N": "gc10",
@@ -2102,7 +2102,7 @@
                                                   "card": "1:1",
                                                   "sType": "1AB",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "1469",
+                                                  "line": "1473",
                                                   "C": [
                                                     {
                                                       "N": "axis",
@@ -2137,7 +2137,7 @@
                                           "var": "Q{}nillable",
                                           "slot": "4",
                                           "sType": "* ",
-                                          "line": "1471",
+                                          "line": "1475",
                                           "C": [
                                             {
                                               "N": "doc",
@@ -2148,12 +2148,12 @@
                                                 {
                                                   "N": "choose",
                                                   "sType": "? ",
-                                                  "line": "1472",
+                                                  "line": "1476",
                                                   "C": [
                                                     {
                                                       "N": "docOrder",
                                                       "sType": "*NA nQ{}nillable",
-                                                      "line": "1472",
+                                                      "line": "1476",
                                                       "C": [
                                                         {
                                                           "N": "slash",
@@ -2203,7 +2203,7 @@
                                             {
                                               "N": "choose",
                                               "sType": "* ",
-                                              "line": "1475",
+                                              "line": "1479",
                                               "C": [
                                                 {
                                                   "N": "gc10",
@@ -2212,7 +2212,7 @@
                                                   "card": "1:1",
                                                   "sType": "1AB",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "1475",
+                                                  "line": "1479",
                                                   "C": [
                                                     {
                                                       "N": "arith10",
@@ -2345,7 +2345,7 @@
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "1477",
+                                                      "line": "1481",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -2373,7 +2373,7 @@
                                                                               "slot": "2",
                                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                               "role": "select",
-                                                                              "line": "1477"
+                                                                              "line": "1481"
                                                                             }
                                                                           ]
                                                                         }
@@ -2405,13 +2405,13 @@
                                                     {
                                                       "N": "choose",
                                                       "sType": "? ",
-                                                      "line": "1478",
+                                                      "line": "1482",
                                                       "C": [
                                                         {
                                                           "N": "and",
                                                           "sType": "1AB",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                          "line": "1478",
+                                                          "line": "1482",
                                                           "C": [
                                                             {
                                                               "N": "fn",
@@ -2481,7 +2481,7 @@
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "1481",
+                                                      "line": "1485",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -2509,7 +2509,7 @@
                                                                               "slot": "3",
                                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                               "role": "select",
-                                                                              "line": "1481"
+                                                                              "line": "1485"
                                                                             }
                                                                           ]
                                                                         }
@@ -2541,13 +2541,13 @@
                                                     {
                                                       "N": "choose",
                                                       "sType": "? ",
-                                                      "line": "1482",
+                                                      "line": "1486",
                                                       "C": [
                                                         {
                                                           "N": "and",
                                                           "sType": "1AB",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                          "line": "1482",
+                                                          "line": "1486",
                                                           "C": [
                                                             {
                                                               "N": "gc10",
@@ -2658,7 +2658,7 @@
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "1485",
+                                                      "line": "1489",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -2686,7 +2686,7 @@
                                                                               "slot": "4",
                                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                               "role": "select",
-                                                                              "line": "1485"
+                                                                              "line": "1489"
                                                                             }
                                                                           ]
                                                                         }
@@ -2718,13 +2718,13 @@
                                                     {
                                                       "N": "choose",
                                                       "sType": "? ",
-                                                      "line": "1486",
+                                                      "line": "1490",
                                                       "C": [
                                                         {
                                                           "N": "and",
                                                           "sType": "1AB",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                          "line": "1486",
+                                                          "line": "1490",
                                                           "C": [
                                                             {
                                                               "N": "gc10",
@@ -2864,7 +2864,7 @@
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "1489",
+                                                      "line": "1493",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -2889,7 +2889,7 @@
                                                                               "N": "docOrder",
                                                                               "sType": "*NA nQ{}use",
                                                                               "role": "select",
-                                                                              "line": "1489",
+                                                                              "line": "1493",
                                                                               "C": [
                                                                                 {
                                                                                   "N": "slash",
@@ -2979,7 +2979,7 @@
                           "var": "Q{}recursion.label",
                           "slot": "3",
                           "sType": "* ",
-                          "line": "1495",
+                          "line": "1499",
                           "C": [
                             {
                               "N": "fn",
@@ -2987,7 +2987,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1495",
+                              "line": "1499",
                               "C": [
                                 { "N": "str", "val": "[" },
                                 {
@@ -3015,7 +3015,7 @@
                               "var": "Q{}recursion.test",
                               "slot": "4",
                               "sType": "* ",
-                              "line": "1496",
+                              "line": "1500",
                               "C": [
                                 {
                                   "N": "doc",
@@ -3028,7 +3028,7 @@
                                       "bSlot": "1",
                                       "sType": "* ",
                                       "name": "Q{}recursion.should.continue",
-                                      "line": "1497",
+                                      "line": "1501",
                                       "C": [
                                         {
                                           "N": "withParam",
@@ -3043,7 +3043,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1498"
+                                              "line": "1502"
                                             }
                                           ]
                                         },
@@ -3060,7 +3060,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1499"
+                                              "line": "1503"
                                             }
                                           ]
                                         },
@@ -3076,7 +3076,7 @@
                                               "bSlot": "2",
                                               "sType": "* ",
                                               "role": "select",
-                                              "line": "1500"
+                                              "line": "1504"
                                             }
                                           ]
                                         }
@@ -3087,7 +3087,7 @@
                                 {
                                   "N": "choose",
                                   "sType": "? ",
-                                  "line": "1504",
+                                  "line": "1508",
                                   "C": [
                                     {
                                       "N": "gc10",
@@ -3096,7 +3096,7 @@
                                       "card": "1:1",
                                       "sType": "1AB",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1504",
+                                      "line": "1508",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -3129,7 +3129,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "1505",
+                                      "line": "1509",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -3152,7 +3152,7 @@
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1506",
+                                              "line": "1510",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -3180,7 +3180,7 @@
                                                                       "slot": "2",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1506"
+                                                                      "line": "1510"
                                                                     }
                                                                   ]
                                                                 }
@@ -3212,7 +3212,7 @@
                                               "var": "Q{}elem-type",
                                               "slot": "5",
                                               "sType": "* ",
-                                              "line": "1508",
+                                              "line": "1512",
                                               "C": [
                                                 {
                                                   "N": "let",
@@ -3220,7 +3220,7 @@
                                                   "slot": "199",
                                                   "xpath": "$consolidated-xsd[@name = $type-local-name and (not(contains(local-name(current()), 'element')) or contains(local-name(), 'Type'))][1]",
                                                   "loc": "xsl:variable/@select",
-                                                  "line": "1508",
+                                                  "line": "1512",
                                                   "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                                                   "role": "select",
                                                   "BC": "true",
@@ -3349,7 +3349,7 @@
                                                     {
                                                       "N": "choose",
                                                       "sType": "* ",
-                                                      "line": "1509",
+                                                      "line": "1513",
                                                       "C": [
                                                         {
                                                           "N": "gc10",
@@ -3358,7 +3358,7 @@
                                                           "card": "1:1",
                                                           "sType": "1AB",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                          "line": "1509",
+                                                          "line": "1513",
                                                           "C": [
                                                             {
                                                               "N": "fn",
@@ -3393,7 +3393,7 @@
                                                           "bSlot": "4",
                                                           "sType": "* ",
                                                           "name": "Q{}render-type.write-name",
-                                                          "line": "1510",
+                                                          "line": "1514",
                                                           "C": [
                                                             {
                                                               "N": "withParam",
@@ -3408,7 +3408,7 @@
                                                                   "sType": "*",
                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                   "role": "select",
-                                                                  "line": "1511"
+                                                                  "line": "1515"
                                                                 }
                                                               ]
                                                             }
@@ -3425,7 +3425,7 @@
                                                       "N": "choose",
                                                       "sType": "* ",
                                                       "type": "item()*",
-                                                      "line": "1515",
+                                                      "line": "1519",
                                                       "C": [
                                                         {
                                                           "N": "varRef",
@@ -3433,12 +3433,12 @@
                                                           "slot": "5",
                                                           "sType": "*",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                          "line": "1516"
+                                                          "line": "1520"
                                                         },
                                                         {
                                                           "N": "applyT",
                                                           "sType": "* ",
-                                                          "line": "1518",
+                                                          "line": "1522",
                                                           "mode": "Q{}render-type",
                                                           "bSlot": "5",
                                                           "C": [
@@ -3449,7 +3449,7 @@
                                                               "sType": "*",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1518"
+                                                              "line": "1522"
                                                             },
                                                             {
                                                               "N": "withParam",
@@ -3463,7 +3463,7 @@
                                                                   "sType": "1AS",
                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                   "role": "select",
-                                                                  "line": "1519",
+                                                                  "line": "1523",
                                                                   "C": [
                                                                     {
                                                                       "N": "atomSing",
@@ -3509,7 +3509,7 @@
                                                         {
                                                           "N": "applyT",
                                                           "sType": "* ",
-                                                          "line": "1524",
+                                                          "line": "1528",
                                                           "mode": "Q{}render-type",
                                                           "bSlot": "5",
                                                           "C": [
@@ -3517,7 +3517,7 @@
                                                               "N": "docOrder",
                                                               "sType": "*NE",
                                                               "role": "select",
-                                                              "line": "1524",
+                                                              "line": "1528",
                                                               "C": [
                                                                 {
                                                                   "N": "slash",
@@ -3558,7 +3558,7 @@
                                                                   "sType": "1AS",
                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                   "role": "select",
-                                                                  "line": "1525",
+                                                                  "line": "1529",
                                                                   "C": [
                                                                     {
                                                                       "N": "atomSing",
@@ -3643,7 +3643,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}render-type.write-name",
-          "line": "1533",
+          "line": "1537",
           "expand-text": "false",
           "sType": "* ",
           "C": [
@@ -3659,7 +3659,7 @@
                   "sType": "* ",
                   "as": "* ",
                   "flags": "",
-                  "line": "1534",
+                  "line": "1538",
                   "C": [
                     {
                       "N": "str",
@@ -3686,7 +3686,7 @@
                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}big ",
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                  "line": "1536",
+                  "line": "1540",
                   "C": [
                     {
                       "N": "elem",
@@ -3694,13 +3694,13 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "1537",
+                      "line": "1541",
                       "C": [
                         {
                           "N": "choose",
                           "sType": "?NT ",
                           "type": "item()*",
-                          "line": "1538",
+                          "line": "1542",
                           "C": [
                             {
                               "N": "varRef",
@@ -3708,13 +3708,13 @@
                               "slot": "0",
                               "sType": "*",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                              "line": "1539"
+                              "line": "1543"
                             },
                             {
                               "N": "valueOf",
                               "flags": "l",
                               "sType": "1NT ",
-                              "line": "1540",
+                              "line": "1544",
                               "C": [
                                 {
                                   "N": "fn",
@@ -3742,7 +3742,7 @@
                                                       "slot": "0",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1540"
+                                                      "line": "1544"
                                                     }
                                                   ]
                                                 }
@@ -3800,7 +3800,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}src.elem",
-          "line": "1900",
+          "line": "1904",
           "expand-text": "false",
           "sType": "* ",
           "C": [
@@ -3816,7 +3816,7 @@
                   "sType": "* ",
                   "as": "* ",
                   "flags": "",
-                  "line": "1901",
+                  "line": "1905",
                   "C": [
                     {
                       "N": "str",
@@ -3839,7 +3839,7 @@
                   "sType": "* ",
                   "as": "* ",
                   "flags": "",
-                  "line": "1902",
+                  "line": "1906",
                   "C": [
                     {
                       "N": "str",
@@ -3859,7 +3859,7 @@
                   "N": "valueOf",
                   "flags": "l",
                   "sType": "1NT ",
-                  "line": "1905",
+                  "line": "1909",
                   "C": [
                     {
                       "N": "fn",
@@ -3875,7 +3875,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1905",
+                              "line": "1909",
                               "C": [
                                 { "N": "str", "val": "<" },
                                 {
@@ -3926,14 +3926,14 @@
                 {
                   "N": "choose",
                   "sType": "* ",
-                  "line": "1906",
+                  "line": "1910",
                   "C": [
                     {
                       "N": "fn",
                       "name": "not",
                       "sType": "1AB",
                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                      "line": "1906",
+                      "line": "1910",
                       "C": [
                         {
                           "N": "varRef",
@@ -3949,7 +3949,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1907",
+                          "line": "1911",
                           "mode": "Q{}src",
                           "bSlot": "0",
                           "C": [
@@ -3957,7 +3957,7 @@
                               "N": "docOrder",
                               "sType": "*NA",
                               "role": "select",
-                              "line": "1907",
+                              "line": "1911",
                               "C": [
                                 {
                                   "N": "slash",
@@ -3987,7 +3987,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1908",
+                          "line": "1912",
                           "mode": "Q{}src.namespace",
                           "bSlot": "1",
                           "C": [
@@ -3996,7 +3996,7 @@
                               "sType": "1",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1908"
+                              "line": "1912"
                             }
                           ]
                         }
@@ -4010,7 +4010,7 @@
                   "N": "valueOf",
                   "flags": "l",
                   "sType": "1NT ",
-                  "line": "1910",
+                  "line": "1914",
                   "C": [
                     {
                       "N": "fn",
@@ -4026,7 +4026,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1910",
+                              "line": "1914",
                               "C": [
                                 {
                                   "N": "atomSing",
@@ -4074,7 +4074,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}head.render",
-          "line": "2027",
+          "line": "2031",
           "expand-text": "false",
           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}head ",
           "C": [
@@ -4085,7 +4085,7 @@
               "nsuri": "http://www.w3.org/1999/xhtml",
               "namespaces": "=http://www.w3.org/1999/xhtml",
               "role": "body",
-              "line": "2028",
+              "line": "2032",
               "C": [
                 {
                   "N": "sequence",
@@ -4097,13 +4097,13 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}title ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2029",
+                      "line": "2033",
                       "C": [
                         {
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "2030",
+                          "line": "2034",
                           "C": [
                             {
                               "N": "fn",
@@ -4119,7 +4119,7 @@
                                       "sType": "1AS",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "2030",
+                                      "line": "2034",
                                       "C": [
                                         {
                                           "N": "atomSing",
@@ -4155,7 +4155,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}meta ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2032",
+                      "line": "2036",
                       "C": [
                         {
                           "N": "sequence",
@@ -4197,7 +4197,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}meta ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2033",
+                      "line": "2037",
                       "C": [
                         {
                           "N": "sequence",
@@ -4239,7 +4239,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}meta ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2034",
+                      "line": "2038",
                       "C": [
                         {
                           "N": "sequence",
@@ -4281,7 +4281,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}meta ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2035",
+                      "line": "2039",
                       "C": [
                         {
                           "N": "sequence",
@@ -4323,7 +4323,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}meta ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2037",
+                      "line": "2041",
                       "C": [
                         {
                           "N": "sequence",
@@ -4361,7 +4361,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}meta ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2038",
+                      "line": "2042",
                       "C": [
                         {
                           "N": "sequence",
@@ -4399,7 +4399,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}style ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2040",
+                      "line": "2044",
                       "C": [
                         {
                           "N": "sequence",
@@ -4422,7 +4422,7 @@
                               "N": "valueOf",
                               "flags": "d",
                               "sType": "1NT ",
-                              "line": "2041",
+                              "line": "2045",
                               "C": [
                                 {
                                   "N": "fn",
@@ -4449,7 +4449,7 @@
                                                       "name": "Q{}css",
                                                       "bSlot": "1",
                                                       "role": "select",
-                                                      "line": "2041"
+                                                      "line": "2045"
                                                     }
                                                   ]
                                                 }
@@ -4495,7 +4495,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}body.render",
-          "line": "2054",
+          "line": "2058",
           "expand-text": "false",
           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}body ",
           "C": [
@@ -4506,7 +4506,7 @@
               "nsuri": "http://www.w3.org/1999/xhtml",
               "namespaces": "=http://www.w3.org/1999/xhtml",
               "role": "body",
-              "line": "2055",
+              "line": "2059",
               "C": [
                 {
                   "N": "sequence",
@@ -4527,7 +4527,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2056",
+                      "line": "2060",
                       "C": [
                         {
                           "N": "sequence",
@@ -4552,7 +4552,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "2057",
+                              "line": "2061",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -4576,14 +4576,14 @@
                                       "bSlot": "0",
                                       "sType": "* ",
                                       "name": "Q{}title.render",
-                                      "line": "2058"
+                                      "line": "2062"
                                     },
                                     {
                                       "N": "callT",
                                       "bSlot": "1",
                                       "sType": "* ",
                                       "name": "Q{}content.render",
-                                      "line": "2065"
+                                      "line": "2069"
                                     }
                                   ]
                                 }
@@ -4614,7 +4614,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}title.render",
-          "line": "2079",
+          "line": "2083",
           "expand-text": "false",
           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
           "C": [
@@ -4625,7 +4625,7 @@
               "nsuri": "http://www.w3.org/1999/xhtml",
               "namespaces": "=http://www.w3.org/1999/xhtml",
               "role": "body",
-              "line": "2080",
+              "line": "2084",
               "C": [
                 {
                   "N": "sequence",
@@ -4644,13 +4644,13 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}h1 ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2081",
+                      "line": "2085",
                       "C": [
                         {
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "2082",
+                          "line": "2086",
                           "C": [
                             {
                               "N": "fn",
@@ -4677,7 +4677,7 @@
                                                   "name": "Q{}html-title",
                                                   "bSlot": "0",
                                                   "role": "select",
-                                                  "line": "2082"
+                                                  "line": "2086"
                                                 }
                                               ]
                                             }
@@ -4721,7 +4721,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}navig.render",
-          "line": "2095",
+          "line": "2099",
           "expand-text": "false",
           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
           "C": [
@@ -4732,7 +4732,7 @@
               "nsuri": "http://www.w3.org/1999/xhtml",
               "namespaces": "=http://www.w3.org/1999/xhtml",
               "role": "body",
-              "line": "2096",
+              "line": "2100",
               "C": [
                 {
                   "N": "sequence",
@@ -4751,7 +4751,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2097",
+                      "line": "2101",
                       "C": [
                         {
                           "N": "sequence",
@@ -4785,7 +4785,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}ul ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "2098",
+                              "line": "2102",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -4797,7 +4797,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}li ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "2099",
+                                      "line": "2103",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -4822,7 +4822,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "2100",
+                                              "line": "2104",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -4866,7 +4866,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}li ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "2102",
+                                      "line": "2106",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -4891,7 +4891,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "2103",
+                                              "line": "2107",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -4935,7 +4935,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}li ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "2105",
+                                      "line": "2109",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -4960,7 +4960,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "2106",
+                                              "line": "2110",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -5004,7 +5004,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}li ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "2113",
+                                      "line": "2117",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -5029,7 +5029,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "2114",
+                                              "line": "2118",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -5109,7 +5109,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}content.render",
-          "line": "2129",
+          "line": "2133",
           "expand-text": "false",
           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
           "C": [
@@ -5120,7 +5120,7 @@
               "nsuri": "http://www.w3.org/1999/xhtml",
               "namespaces": "=http://www.w3.org/1999/xhtml",
               "role": "body",
-              "line": "2130",
+              "line": "2134",
               "C": [
                 {
                   "N": "sequence",
@@ -5136,21 +5136,21 @@
                     {
                       "N": "choose",
                       "sType": "* ",
-                      "line": "2131",
+                      "line": "2135",
                       "C": [
                         {
                           "N": "gVarRef",
                           "name": "Q{}ENABLE-SERVICE-PARAGRAPH",
                           "bSlot": "0",
                           "sType": "* ",
-                          "line": "2131"
+                          "line": "2135"
                         },
                         {
                           "N": "callT",
                           "bSlot": "1",
                           "sType": "* ",
                           "name": "Q{}service.render",
-                          "line": "2132"
+                          "line": "2136"
                         },
                         { "N": "true" },
                         { "N": "empty", "sType": "0 " }
@@ -5159,21 +5159,21 @@
                     {
                       "N": "choose",
                       "sType": "* ",
-                      "line": "2134",
+                      "line": "2138",
                       "C": [
                         {
                           "N": "gVarRef",
                           "name": "Q{}ENABLE-OPERATIONS-PARAGRAPH",
                           "bSlot": "2",
                           "sType": "* ",
-                          "line": "2134"
+                          "line": "2138"
                         },
                         {
                           "N": "callT",
                           "bSlot": "3",
                           "sType": "* ",
                           "name": "Q{}operations.render",
-                          "line": "2135"
+                          "line": "2139"
                         },
                         { "N": "true" },
                         { "N": "empty", "sType": "0 " }
@@ -5182,21 +5182,21 @@
                     {
                       "N": "choose",
                       "sType": "* ",
-                      "line": "2137",
+                      "line": "2141",
                       "C": [
                         {
                           "N": "gVarRef",
                           "name": "Q{}ENABLE-SRC-CODE-PARAGRAPH",
                           "bSlot": "4",
                           "sType": "* ",
-                          "line": "2137"
+                          "line": "2141"
                         },
                         {
                           "N": "callT",
                           "bSlot": "5",
                           "sType": "* ",
                           "name": "Q{}src.render",
-                          "line": "2138"
+                          "line": "2142"
                         },
                         { "N": "true" },
                         { "N": "empty", "sType": "0 " }
@@ -5223,7 +5223,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}service.render",
-          "line": "2149",
+          "line": "2153",
           "expand-text": "false",
           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
           "C": [
@@ -5234,7 +5234,7 @@
               "nsuri": "http://www.w3.org/1999/xhtml",
               "namespaces": "=http://www.w3.org/1999/xhtml",
               "role": "body",
-              "line": "2150",
+              "line": "2154",
               "C": [
                 {
                   "N": "sequence",
@@ -5253,7 +5253,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2151",
+                      "line": "2155",
                       "C": [
                         {
                           "N": "sequence",
@@ -5287,13 +5287,13 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}h2 ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "2152",
+                              "line": "2156",
                               "C": [
                                 {
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "2153",
+                                  "line": "2157",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -5320,7 +5320,7 @@
                                                           "name": "Q{}html-title",
                                                           "bSlot": "0",
                                                           "role": "select",
-                                                          "line": "2153"
+                                                          "line": "2157"
                                                         }
                                                       ]
                                                     }
@@ -5354,7 +5354,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "2157",
+                      "line": "2161",
                       "mode": "Q{}documentation.render",
                       "bSlot": "1",
                       "C": [
@@ -5362,7 +5362,7 @@
                           "N": "docOrder",
                           "sType": "*NE",
                           "role": "select",
-                          "line": "2157",
+                          "line": "2161",
                           "C": [
                             {
                               "N": "docOrder",
@@ -5416,7 +5416,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "2159",
+                      "line": "2163",
                       "mode": "Q{}service-start",
                       "bSlot": "3",
                       "C": [
@@ -5424,7 +5424,7 @@
                           "N": "docOrder",
                           "sType": "*NE u[NE nQ{http://schemas.xmlsoap.org/wsdl/}service,NE nQ{http://www.w3.org/ns/wsdl}service]",
                           "role": "select",
-                          "line": "2159",
+                          "line": "2163",
                           "C": [
                             {
                               "N": "union",
@@ -5483,14 +5483,14 @@
                     {
                       "N": "choose",
                       "sType": "* ",
-                      "line": "2160",
+                      "line": "2164",
                       "C": [
                         {
                           "N": "fn",
                           "name": "not",
                           "sType": "1AB",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                          "line": "2160",
+                          "line": "2164",
                           "C": [
                             {
                               "N": "docOrder",
@@ -5552,7 +5552,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "2165",
+                              "line": "2169",
                               "mode": "Q{}service-start",
                               "bSlot": "3",
                               "C": [
@@ -5560,7 +5560,7 @@
                                   "N": "docOrder",
                                   "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}binding",
                                   "role": "select",
-                                  "line": "2165",
+                                  "line": "2169",
                                   "C": [
                                     {
                                       "N": "docOrder",
@@ -5592,7 +5592,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "2166",
+                              "line": "2170",
                               "mode": "Q{}service",
                               "bSlot": "4",
                               "C": [
@@ -5600,7 +5600,7 @@
                                   "N": "docOrder",
                                   "sType": "*NE nQ{http://www.w3.org/ns/wsdl}interface",
                                   "role": "select",
-                                  "line": "2166",
+                                  "line": "2170",
                                   "C": [
                                     {
                                       "N": "docOrder",
@@ -5656,7 +5656,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}operations.render",
-          "line": "2179",
+          "line": "2183",
           "expand-text": "false",
           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
           "C": [
@@ -5667,7 +5667,7 @@
               "nsuri": "http://www.w3.org/1999/xhtml",
               "namespaces": "=http://www.w3.org/1999/xhtml",
               "role": "body",
-              "line": "2180",
+              "line": "2184",
               "C": [
                 {
                   "N": "sequence",
@@ -5686,7 +5686,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2181",
+                      "line": "2185",
                       "C": [
                         {
                           "N": "sequence",
@@ -5720,7 +5720,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}h2 ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "2182",
+                              "line": "2186",
                               "C": [
                                 {
                                   "N": "valueOf",
@@ -5745,7 +5745,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}ul ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2184",
+                      "line": "2188",
                       "C": [
                         {
                           "N": "sequence",
@@ -5754,7 +5754,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "2185",
+                              "line": "2189",
                               "mode": "Q{}operations",
                               "bSlot": "0",
                               "C": [
@@ -5767,7 +5767,7 @@
                                       "N": "docOrder",
                                       "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}portType",
                                       "role": "select",
-                                      "line": "2185",
+                                      "line": "2189",
                                       "C": [
                                         {
                                           "N": "docOrder",
@@ -5815,7 +5815,7 @@
                                                   "sType": "*NA nQ{}name",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "2186"
+                                                  "line": "2190"
                                                 }
                                               ]
                                             }
@@ -5855,12 +5855,12 @@
                               "N": "choose",
                               "sType": "* ",
                               "type": "item()*",
-                              "line": "2189",
+                              "line": "2193",
                               "C": [
                                 {
                                   "N": "docOrder",
                                   "sType": "*NA nQ{}name",
-                                  "line": "2190",
+                                  "line": "2194",
                                   "C": [
                                     {
                                       "N": "docOrder",
@@ -5925,7 +5925,7 @@
                                   "var": "Q{}iface-name",
                                   "slot": "0",
                                   "sType": "* ",
-                                  "line": "2191",
+                                  "line": "2195",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -5936,7 +5936,7 @@
                                         {
                                           "N": "applyT",
                                           "sType": "* ",
-                                          "line": "2193",
+                                          "line": "2197",
                                           "mode": "Q{}qname.normalized",
                                           "bSlot": "2",
                                           "C": [
@@ -5944,7 +5944,7 @@
                                               "N": "docOrder",
                                               "sType": "*NA nQ{}interface",
                                               "role": "select",
-                                              "line": "2193",
+                                              "line": "2197",
                                               "C": [
                                                 {
                                                   "N": "docOrder",
@@ -6015,7 +6015,7 @@
                                     {
                                       "N": "applyT",
                                       "sType": "* ",
-                                      "line": "2196",
+                                      "line": "2200",
                                       "mode": "Q{}operations",
                                       "bSlot": "0",
                                       "C": [
@@ -6028,7 +6028,7 @@
                                               "N": "docOrder",
                                               "sType": "*NE nQ{http://www.w3.org/ns/wsdl}interface",
                                               "role": "select",
-                                              "line": "2196",
+                                              "line": "2200",
                                               "C": [
                                                 {
                                                   "N": "docOrder",
@@ -6099,7 +6099,7 @@
                                                           "sType": "*NA nQ{}name",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "2197"
+                                                          "line": "2201"
                                                         }
                                                       ]
                                                     }
@@ -6140,7 +6140,7 @@
                                 {
                                   "N": "docOrder",
                                   "sType": "*NA nQ{}name",
-                                  "line": "2200",
+                                  "line": "2204",
                                   "C": [
                                     {
                                       "N": "docOrder",
@@ -6181,7 +6181,7 @@
                                 {
                                   "N": "applyT",
                                   "sType": "* ",
-                                  "line": "2205",
+                                  "line": "2209",
                                   "mode": "Q{}operations",
                                   "bSlot": "0",
                                   "C": [
@@ -6189,7 +6189,7 @@
                                       "N": "docOrder",
                                       "sType": "*NE nQ{http://www.w3.org/ns/wsdl}interface",
                                       "role": "select",
-                                      "line": "2205",
+                                      "line": "2209",
                                       "C": [
                                         {
                                           "N": "docOrder",
@@ -6252,7 +6252,7 @@
           "slots": "200",
           "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
           "name": "Q{}src.render",
-          "line": "2226",
+          "line": "2230",
           "expand-text": "false",
           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
           "C": [
@@ -6263,7 +6263,7 @@
               "nsuri": "http://www.w3.org/1999/xhtml",
               "namespaces": "=http://www.w3.org/1999/xhtml",
               "role": "body",
-              "line": "2227",
+              "line": "2231",
               "C": [
                 {
                   "N": "sequence",
@@ -6282,7 +6282,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2228",
+                      "line": "2232",
                       "C": [
                         {
                           "N": "sequence",
@@ -6316,7 +6316,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}h2 ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "2229",
+                              "line": "2233",
                               "C": [
                                 {
                                   "N": "valueOf",
@@ -6341,7 +6341,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "2231",
+                      "line": "2235",
                       "C": [
                         {
                           "N": "sequence",
@@ -6362,7 +6362,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "2232",
+                              "line": "2236",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -6399,7 +6399,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "2235",
+                              "line": "2239",
                               "mode": "Q{}src",
                               "bSlot": "0",
                               "C": [
@@ -6413,7 +6413,7 @@
                                       "role": "select",
                                       "simple": "1",
                                       "sType": "?N",
-                                      "line": "2235",
+                                      "line": "2239",
                                       "C": [
                                         {
                                           "N": "treat",
@@ -6439,7 +6439,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "2238",
+                      "line": "2242",
                       "mode": "Q{}src.import",
                       "bSlot": "1",
                       "C": [
@@ -6447,7 +6447,7 @@
                           "N": "docOrder",
                           "sType": "*NA nQ{}location",
                           "role": "select",
-                          "line": "2238",
+                          "line": "2242",
                           "C": [
                             {
                               "N": "docOrder",
@@ -6529,7 +6529,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "2240",
+                      "line": "2244",
                       "mode": "Q{}src.import",
                       "bSlot": "1",
                       "C": [
@@ -6537,7 +6537,7 @@
                           "N": "docOrder",
                           "sType": "*NA nQ{}schemaLocation",
                           "role": "select",
-                          "line": "2240",
+                          "line": "2244",
                           "C": [
                             {
                               "N": "union",
@@ -8344,7 +8344,7 @@
                     {
                       "N": "str",
                       "sType": "1AS ",
-                      "val": "\n\n/**\n\twsdl-viewer.css\n*/\n\n/**\n=========================================\n\tBody\n=========================================\n*/\n\nbody {\n\tmargin: 0;\n\tpadding: 0;\n\theight: auto;\n}\n\n/**\n=========================================\n\tFixed box with links\n=========================================\n*/\n#outer_links { \n\tposition: fixed;\n\tleft: 0px;\n\ttop: 0px;\n\tmargin: 3px;\n\tpadding: 1px;\n\tz-index: 200; \n\twidth: 180px;\n\theight: auto;\n\tbackground-color: gainsboro;\n\tpadding-top: 2px;\n\tborder: 1px solid navy;\n}\n\n* html #outer_links /* Override above rule for IE */ \n{ \n\tposition: absolute; \n\twidth: 188px;\n\ttop: expression(offsetParent.scrollTop + 0); \n} \n\n#links {\n\tmargin: 1px;\n\tpadding: 3px;\n\tbackground-color: white;\n\theight: 350px;\n\toverflow: auto;\n\tborder: 1px solid navy;\n}\n\n#links ul {\n\tleft: -999em;\n\tlist-style: none;\n\tmargin: 0;\n\tpadding: 0;\n\tz-index: 100;\n}\n\n#links li {\n\tmargin: 0;\n\tpadding: 2px 4px;\n\twidth: auto;\n\tz-index: 100;\n}\n\n#links ul li {\n\tmargin: 0;\n\tpadding: 2px 4px;\n\twidth: auto;\n\tz-index: 100;\n}\n\n#links a {\n\tdisplay: block;\n\tpadding: 0 2px;\n\tcolor: blue;\n\twidth: auto;\n\tborder: 1px solid white;\n\ttext-decoration: none;\n\twhite-space: nowrap;\n}\n\n#links a:hover {\n\tcolor: white;\n\tbackground-color: gray;\n\tborder: 1px solid gray;\n} \n\n\n/**\n=========================================\n\tNavigation tabs\n=========================================\n*/\n\n#outer_nav {\n\tbackground-color: yellow;\n\tpadding: 0;\n\tmargin: 0;\n}\n\n#nav {\n\theight: 100%;\n\twidth: auto;\n\tmargin: 0;\n\tpadding: 0;\n\tbackground-color: gainsboro;\n\tborder-top: 1px solid gray;\n\tborder-bottom: 3px solid gray;\n\tz-index: 100;\n\tfont: bold 90%/120% Arial, Helvetica, sans-serif;\n\tletter-spacing: 2px;\n} \n\n#nav ul { \n\tbackground-color: gainsboro;\n\theight: auto;\n\twidth: auto;\n\tlist-style: none;\n\tmargin: 0;\n\tpadding: 0;\n\tz-index: 100;\n\n\tborder: 1px solid silver; \n\tborder-top-color: black; \n\tborder-width: 1px 0 9px; \n} \n\n#nav li { \n\tdisplay: inline; \n\tpadding: 0;\n\tmargin: 0;\n} \n\n#nav a { \n\tposition: relative;\n\ttop: 3px;\n\tfloat:left; \n\twidth:auto; \n\tpadding: 8px 10px 6px 10px;\n\tmargin: 3px 3px 0;\n\tborder: 1px solid gray; \n\tborder-width: 2px 2px 3px 2px;\n\n\tcolor: black; \n\tbackground-color: silver; \n\ttext-decoration:none; \n\ttext-transform: uppercase;\n}\n\n#nav a:hover { \n\tmargin-top: 1px;\n\tpadding-top: 9px;\n\tpadding-bottom: 7px;\n\tcolor: blue;\n\tbackground-color: gainsboro;\n} \n\n#nav a.current:link,\n#nav a.current:visited,\n#nav a.current:hover {\n\tbackground: white; \n\tcolor: black; \n\ttext-shadow:none; \n\tmargin-top: 0;\n\tpadding-top: 11px;\n\tpadding-bottom: 9px;\n\tborder-bottom-width: 0;\n\tborder-color: red; \n}\n\n#nav a:active { \n\tbackground-color: silver; \n\tcolor: white;\n} \n\n\n\n/**\n=========================================\n\tContent\n=========================================\n*/\n#header {\n\tdisplay: none;\n}\n\n#content {\n\tmargin: 0;\n}\n\n.single_column {\n\tpadding: 10px 10px 10px 10px;\n\t/*margin: 0px 33% 0px 0px; */\n\tmargin: 3px 0;\n}\n\n#flexi_column {\n\tpadding: 10px 10px 10px 10px;\n\t/*margin: 0px 33% 0px 0px; */\n\tmargin: 0px 212px 0px 0px;\n}\n\n#fix_column {\n\tfloat: right;\n\tpadding: 10px 10px 10px 10px;\n\tmargin: 0px;\n\twidth: 205px;\n\t/*width: 30%; */\n\tvoice-family: \"\\\"}\\\"\";\n\tvoice-family:inherit;\n\t/* width: 30%; */\n\twidth: 205px;\n}\nhtml>body #rightColumn {\n\twidth: 205px; /* ie5win fudge ends */\n} /* Opera5.02 shows a 2px gap between. N6.01Win sometimes does.\n\tDepends on amount of fill and window size and wind direction. */\n\n/**\n=========================================\n\tLabel / value\n=========================================\n*/\n\n.page {\n\tborder-bottom: 3px dotted navy;\n\tmargin: 0;\n\tpadding: 10px 0 20px 0;\n}\n\n.page:last-child {\n    border: none;\n}\n\n.value, .label {\n\tmargin: 0;\n\tpadding: 0;\n}\n\n.label {\n\tfloat: left;\n\twidth: 140px;\n\ttext-align: right;\n\tfont-weight: bold;\n\tpadding-bottom: .5em;\n\tmargin-right: 0;\n\tcolor: darkblue;\n}\n\n.value {\n\tmargin-left: 147px;\n\tcolor: darkblue;\n\tpadding-bottom: .5em;\n}\n\nstrong, strong a {\n\tcolor: darkblue;\n\tfont-weight: bold;\n\tletter-spacing: 1px;\n\tmargin-left: 2px;\n}\n\n\n/**\n=========================================\n\tLinks\n=========================================\n*/\n\na.local:link,\na.local:visited {\n\tcolor: blue; \n\tmargin-left: 10px;\n\tborder-bottom: 1px dotted blue;\n\ttext-decoration: none;\n\tfont-style: italic;\n}\n\na.local:hover {\n\tbackground-color: gainsboro; \n\tcolor: darkblue;\n\tpadding-bottom: 1px;\n\tborder-bottom: 1px solid darkblue;\n}\n\na.target:link,\na.target:visited,\na.target:hover\n{\n\ttext-decoration: none;\n\tbackground-color: transparent;\n\tborder-bottom-type: none;\n}\n\n/**\n=========================================\n\tBox, Shadow\n=========================================\n*/\n\n.box {\n\tpadding: 6px;\n\tcolor: black;\n\tbackground-color: gainsboro;\n\tborder: 1px solid gray;\n}\n\n.shadow {\n\tbackground: silver;\n\tposition: relative;\n\ttop: 5px;\n\tleft: 4px;\n}\n\n.shadow div {\n\tposition: relative;\n\ttop: -5px;\n\tleft: -4px;\n}\n\n/**\n=========================================\n\tFloatcontainer\n=========================================\n*/\n\n.spacer\n{\n\tdisplay: block;\n\theight: 0;\n\tfont-size: 0;\n\tline-height: 0;\n\tmargin: 0;\n\tpadding: 0;\n\tborder-style: none;\n\tclear: both; \n\tvisibility:hidden;\n}\n\n.floatcontainer:after {\n\tcontent: \".\";\n\tdisplay: block;\n\theight: 0;\n\tfont-size:0; \n\tclear: both;\n\tvisibility:hidden;\n}\n.floatcontainer{\n\tdisplay: inline-table;\n} /* Mark Hadley's fix for IE Mac */ /* Hides from IE Mac \\*/ * \nhtml .floatcontainer {\n\theight: 1%;\n}\n.floatcontainer{\n\tdisplay:block;\n} /* End Hack \n*/ \n\n/**\n=========================================\n\tSource code\n=========================================\n*/\n\n.indent {\n\tmargin: 2px 0 2px 20px;\n}\n\n.xml-element, .xml-proc, .xml-comment {\n\tmargin: 2px 0;\n\tpadding: 2px 0 2px 0;\n}\n\n.xml-element {\n\tword-spacing: 3px;\n\tcolor: red;\n\tfont-weight: bold;\n\tfont-style:normal;\n\tborder-left: 1px dotted silver;\n}\n\n.xml-element div {\n\tmargin: 2px 0 2px 40px;\n}\n\n.xml-att {\n\tcolor: blue;\n\tfont-weight: bold;\n}\n\n.xml-att-val {\n\tcolor: blue;\n\tfont-weight: normal;\n}\n\n.xml-proc {\n\tcolor: darkred;\n\tfont-weight: normal;\n\tfont-style: italic;\n}\n\n.xml-comment {\n\tcolor: green;\n\tfont-weight: normal;\n\tfont-style: italic;\n}\n\n.xml-text {\n\tcolor: green;\n\tfont-weight: normal;\n\tfont-style: normal;\n}\n\n\n/**\n=========================================\n\tHeading\n=========================================\n*/\nh1, h2, h3 {\n\tmargin: 10px 10px 2px;\n\tfont-weight: normal;\n\t}\n\nh1 {\n\tfont-weight: bold;\n\tletter-spacing: 3px;\n\tfont-size: 220%;\n\tline-height: 100%;\n}\n\nh2 {\n\tfont-weight: bold;\n\tfont-size: 175%;\n\tline-height: 200%;\n}\n\nh3 {\n\tfont-size: 150%;\n\tline-height: 150%;\n\tfont-style: italic;\n}\n\n/**\n=========================================\n\tContent formatting\n=========================================\n*/\n.port {\n\tmargin-bottom: 10px;\n\tpadding-bottom: 10px;\n\tborder-bottom: 1px dashed gray;\n}\n\n.operation {\n\tmargin-bottom: 20px;\n\tpadding-bottom: 10px;\n\tborder-bottom: 1px dashed gray;\n}\n\n"
+                      "val": "\n\n/**\n\twsdl-viewer.css\n*/\n\n/**\n=========================================\n\tBody\n=========================================\n*/\n\nbody {\n\tmargin: 0;\n\tpadding: 0;\n\theight: auto;\n}\n\n/**\n=========================================\n\tFixed box with links\n=========================================\n*/\n#outer_links { \n\tposition: fixed;\n\tleft: 0px;\n\ttop: 0px;\n\tmargin: 3px;\n\tpadding: 1px;\n\tz-index: 200; \n\twidth: 180px;\n\theight: auto;\n\tbackground-color: gainsboro;\n\tpadding-top: 2px;\n\tborder: 1px solid navy;\n}\n\n* html #outer_links /* Override above rule for IE */ \n{ \n\tposition: absolute; \n\twidth: 188px;\n\ttop: expression(offsetParent.scrollTop + 0); \n} \n\n#links {\n\tmargin: 1px;\n\tpadding: 3px;\n\tbackground-color: white;\n\theight: 350px;\n\toverflow: auto;\n\tborder: 1px solid navy;\n}\n\n#links ul {\n\tleft: -999em;\n\tlist-style: none;\n\tmargin: 0;\n\tpadding: 0;\n\tz-index: 100;\n}\n\n#links li {\n\tmargin: 0;\n\tpadding: 2px 4px;\n\twidth: auto;\n\tz-index: 100;\n}\n\n#links ul li {\n\tmargin: 0;\n\tpadding: 2px 4px;\n\twidth: auto;\n\tz-index: 100;\n}\n\n#links a {\n\tdisplay: block;\n\tpadding: 0 2px;\n\tcolor: blue;\n\twidth: auto;\n\tborder: 1px solid white;\n\ttext-decoration: none;\n\twhite-space: nowrap;\n}\n\n#links a:hover {\n\tcolor: white;\n\tbackground-color: gray;\n\tborder: 1px solid gray;\n} \n\n\n/**\n=========================================\n\tNavigation tabs\n=========================================\n*/\n\n#outer_nav {\n\tbackground-color: yellow;\n\tpadding: 0;\n\tmargin: 0;\n}\n\n#nav {\n\theight: 100%;\n\twidth: auto;\n\tmargin: 0;\n\tpadding: 0;\n\tbackground-color: gainsboro;\n\tborder-top: 1px solid gray;\n\tborder-bottom: 3px solid gray;\n\tz-index: 100;\n\tfont: bold 90%/120% Arial, Helvetica, sans-serif;\n\tletter-spacing: 2px;\n} \n\n#nav ul { \n\tbackground-color: gainsboro;\n\theight: auto;\n\twidth: auto;\n\tlist-style: none;\n\tmargin: 0;\n\tpadding: 0;\n\tz-index: 100;\n\n\tborder: 1px solid silver; \n\tborder-top-color: black; \n\tborder-width: 1px 0 9px; \n} \n\n#nav li { \n\tdisplay: inline; \n\tpadding: 0;\n\tmargin: 0;\n} \n\n#nav a { \n\tposition: relative;\n\ttop: 3px;\n\tfloat:left; \n\twidth:auto; \n\tpadding: 8px 10px 6px 10px;\n\tmargin: 3px 3px 0;\n\tborder: 1px solid gray; \n\tborder-width: 2px 2px 3px 2px;\n\n\tcolor: black; \n\tbackground-color: silver; \n\ttext-decoration:none; \n\ttext-transform: uppercase;\n}\n\n#nav a:hover { \n\tmargin-top: 1px;\n\tpadding-top: 9px;\n\tpadding-bottom: 7px;\n\tcolor: blue;\n\tbackground-color: gainsboro;\n} \n\n#nav a.current:link,\n#nav a.current:visited,\n#nav a.current:hover {\n\tbackground: white; \n\tcolor: black; \n\ttext-shadow:none; \n\tmargin-top: 0;\n\tpadding-top: 11px;\n\tpadding-bottom: 9px;\n\tborder-bottom-width: 0;\n\tborder-color: red; \n}\n\n#nav a:active { \n\tbackground-color: silver; \n\tcolor: white;\n} \n\n\n\n/**\n=========================================\n\tContent\n=========================================\n*/\n#header {\n\tdisplay: none;\n}\n\n#content {\n\tmargin: 0;\n}\n\n.single_column {\n\tpadding: 10px 10px 10px 10px;\n\t/*margin: 0px 33% 0px 0px; */\n\tmargin: 3px 0;\n}\n\n#flexi_column {\n\tpadding: 10px 10px 10px 10px;\n\t/*margin: 0px 33% 0px 0px; */\n\tmargin: 0px 212px 0px 0px;\n}\n\n#fix_column {\n\tfloat: right;\n\tpadding: 10px 10px 10px 10px;\n\tmargin: 0px;\n\twidth: 205px;\n\t/*width: 30%; */\n\tvoice-family: \"\\\"}\\\"\";\n\tvoice-family:inherit;\n\t/* width: 30%; */\n\twidth: 205px;\n}\nhtml>body #rightColumn {\n\twidth: 205px; /* ie5win fudge ends */\n} /* Opera5.02 shows a 2px gap between. N6.01Win sometimes does.\n\tDepends on amount of fill and window size and wind direction. */\n\n/**\n=========================================\n\tLabel / value\n=========================================\n*/\n\n.page {\n\tborder-bottom: 3px dotted rgba(0, 0, 0, 0.87);\n\tmargin: 0;\n\tpadding: 10px 0 20px 0;\n}\n\n.theme-dark .page {\n    border-bottom: 3px dotted #fff;\n}\n\n.page:last-child {\n    border: none;\n}\n\n.value, .label {\n\tmargin: 0;\n\tpadding: 0;\n}\n\n.label {\n\tfloat: left;\n\twidth: 140px;\n\ttext-align: right;\n\tfont-weight: bold;\n\tpadding-bottom: .5em;\n\tmargin-right: 0;\n}\n\n.value {\n\tmargin-left: 147px;\n\tpadding-bottom: .5em;\n}\n\nstrong, strong a {\n\tcolor: darkblue;\n\tfont-weight: bold;\n\tletter-spacing: 1px;\n\tmargin-left: 2px;\n}\n\n\n/**\n=========================================\n\tLinks\n=========================================\n*/\n\na.local:link,\na.local:visited {\n    color: #1F5493;\n\tmargin-left: 10px;\n}\n\na.local:hover {\n    text-decoration: underline;\n}\n\n.theme-dark a.local {\n    color: #9CC9FF;\n}\n\na.target:link,\na.target:visited,\na.target:hover\n{\n\ttext-decoration: none;\n\tbackground-color: transparent;\n\tborder-bottom-type: none;\n}\n\n/**\n=========================================\n\tBox, Shadow\n=========================================\n*/\n\n.box {\n\tpadding: 6px;\n    background-color: #F8F8F8;\n    border-radius: 4px;\n    border: 1px solid rgba(0, 0, 0, 0.12);\n}\n\n.theme-dark .box {\n    color: rgba(0, 0, 0, 0.87);\n}\n\n.shadow {\n\tbackground: silver;\n\tposition: relative;\n\ttop: 5px;\n\tleft: 4px;\n}\n\n.shadow div {\n\tposition: relative;\n\ttop: -5px;\n\tleft: -4px;\n}\n\n/**\n=========================================\n\tFloatcontainer\n=========================================\n*/\n\n.spacer\n{\n\tdisplay: block;\n\theight: 0;\n\tfont-size: 0;\n\tline-height: 0;\n\tmargin: 0;\n\tpadding: 0;\n\tborder-style: none;\n\tclear: both; \n\tvisibility:hidden;\n}\n\n.floatcontainer:after {\n\tcontent: \".\";\n\tdisplay: block;\n\theight: 0;\n\tfont-size:0; \n\tclear: both;\n\tvisibility:hidden;\n}\n.floatcontainer{\n\tdisplay: inline-table;\n} /* Mark Hadley's fix for IE Mac */ /* Hides from IE Mac \\*/ * \nhtml .floatcontainer {\n\theight: 1%;\n}\n.floatcontainer{\n\tdisplay:block;\n} /* End Hack \n*/ \n\n/**\n=========================================\n\tSource code\n=========================================\n*/\n\n.indent {\n\tmargin: 2px 0 2px 20px;\n}\n\n.xml-element, .xml-proc, .xml-comment {\n\tmargin: 2px 0;\n\tpadding: 2px 0 2px 0;\n}\n\n.xml-element {\n\tword-spacing: 3px;\n\tcolor: red;\n\tfont-weight: bold;\n\tfont-style:normal;\n\tborder-left: 1px dotted silver;\n}\n\n.xml-element div {\n\tmargin: 2px 0 2px 40px;\n}\n\n.xml-att {\n\tcolor: blue;\n\tfont-weight: bold;\n}\n\n.xml-att-val {\n\tcolor: blue;\n\tfont-weight: normal;\n}\n\n.xml-proc {\n\tcolor: darkred;\n\tfont-weight: normal;\n\tfont-style: italic;\n}\n\n.xml-comment {\n\tcolor: green;\n\tfont-weight: normal;\n\tfont-style: italic;\n}\n\n.xml-text {\n\tcolor: green;\n\tfont-weight: normal;\n\tfont-style: normal;\n}\n\n\n/**\n=========================================\n\tHeading\n=========================================\n*/\nh1, h2, h3 {\n\tmargin: 10px 10px 2px;\n\tfont-weight: normal;\n\t}\n\nh1 {\n\tfont-weight: bold;\n\tletter-spacing: 3px;\n\tfont-size: 220%;\n\tline-height: 100%;\n}\n\nh2 {\n\tfont-weight: bold;\n\tfont-size: 175%;\n\tline-height: 200%;\n}\n\nh3 {\n\tfont-size: 150%;\n\tline-height: 150%;\n\tfont-style: italic;\n}\n\n/**\n=========================================\n\tContent formatting\n=========================================\n*/\n.port {\n\tmargin-bottom: 10px;\n\tpadding-bottom: 10px;\n\tborder-bottom: 1px dashed gray;\n}\n\n.operation {\n\tmargin-bottom: 20px;\n\tpadding-bottom: 10px;\n\tborder-bottom: 1px dashed gray;\n}\n\n"
                     }
                   ]
                 }
@@ -8376,7 +8376,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "2012",
+              "line": "2016",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "/",
@@ -8397,7 +8397,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "2013",
+                  "line": "2017",
                   "C": [
                     {
                       "N": "sequence",
@@ -8408,14 +8408,14 @@
                           "bSlot": "0",
                           "sType": "* ",
                           "name": "Q{}head.render",
-                          "line": "2014"
+                          "line": "2018"
                         },
                         {
                           "N": "callT",
                           "bSlot": "1",
                           "sType": "* ",
                           "name": "Q{}body.render",
-                          "line": "2015"
+                          "line": "2019"
                         }
                       ]
                     }
@@ -8450,7 +8450,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "557",
+              "line": "561",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "@*",
@@ -8469,7 +8469,7 @@
                   "var": "Q{}local",
                   "slot": "0",
                   "sType": "*NT ",
-                  "line": "558",
+                  "line": "562",
                   "role": "action",
                   "C": [
                     {
@@ -8478,7 +8478,7 @@
                       "sType": "1AS",
                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                       "role": "select",
-                      "line": "558",
+                      "line": "562",
                       "C": [
                         { "N": "fn", "name": "string", "C": [{ "N": "dot" }] },
                         { "N": "str", "val": ":" },
@@ -8492,7 +8492,7 @@
                       "N": "choose",
                       "sType": "?NT ",
                       "type": "item()*",
-                      "line": "559",
+                      "line": "563",
                       "C": [
                         {
                           "N": "varRef",
@@ -8500,13 +8500,13 @@
                           "slot": "0",
                           "sType": "*",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                          "line": "560"
+                          "line": "564"
                         },
                         {
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "561",
+                          "line": "565",
                           "C": [
                             {
                               "N": "fn",
@@ -8534,7 +8534,7 @@
                                                   "slot": "0",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "561"
+                                                  "line": "565"
                                                 }
                                               ]
                                             }
@@ -8560,7 +8560,7 @@
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "564",
+                          "line": "568",
                           "C": [
                             {
                               "N": "fn",
@@ -8586,7 +8586,7 @@
                                                   "sType": "1NA",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "564"
+                                                  "line": "568"
                                                 }
                                               ]
                                             }
@@ -8640,7 +8640,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "568",
+              "line": "572",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:definitions | ws2:description",
@@ -8658,20 +8658,20 @@
                   "sType": "?NT ",
                   "type": "item()*",
                   "role": "action",
-                  "line": "569",
+                  "line": "573",
                   "C": [
                     {
                       "N": "gVarRef",
                       "name": "Q{}global.service-name",
                       "bSlot": "0",
                       "sType": "1AS",
-                      "line": "570"
+                      "line": "574"
                     },
                     {
                       "N": "valueOf",
                       "flags": "l",
                       "sType": "1NT ",
-                      "line": "571",
+                      "line": "575",
                       "C": [
                         {
                           "N": "fn",
@@ -8687,7 +8687,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "571",
+                                  "line": "575",
                                   "C": [
                                     { "N": "str", "val": "Web Service: " },
                                     {
@@ -8709,13 +8709,13 @@
                       "name": "Q{}global.binding-name",
                       "bSlot": "1",
                       "sType": "1AS",
-                      "line": "573"
+                      "line": "577"
                     },
                     {
                       "N": "valueOf",
                       "flags": "l",
                       "sType": "1NT ",
-                      "line": "574",
+                      "line": "578",
                       "C": [
                         {
                           "N": "fn",
@@ -8731,7 +8731,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "574",
+                                  "line": "578",
                                   "C": [
                                     { "N": "str", "val": "WS Binding: " },
                                     {
@@ -8751,7 +8751,7 @@
                     {
                       "N": "docOrder",
                       "sType": "*NA nQ{}name",
-                      "line": "576",
+                      "line": "580",
                       "C": [
                         {
                           "N": "slash",
@@ -8777,7 +8777,7 @@
                       "N": "valueOf",
                       "flags": "l",
                       "sType": "1NT ",
-                      "line": "577",
+                      "line": "581",
                       "C": [
                         {
                           "N": "fn",
@@ -8793,7 +8793,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "577",
+                                  "line": "581",
                                   "C": [
                                     { "N": "str", "val": "WS Interface: " },
                                     {
@@ -8859,7 +8859,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "568",
+              "line": "572",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:definitions | ws2:description",
@@ -8877,20 +8877,20 @@
                   "sType": "?NT ",
                   "type": "item()*",
                   "role": "action",
-                  "line": "569",
+                  "line": "573",
                   "C": [
                     {
                       "N": "gVarRef",
                       "name": "Q{}global.service-name",
                       "bSlot": "0",
                       "sType": "1AS",
-                      "line": "570"
+                      "line": "574"
                     },
                     {
                       "N": "valueOf",
                       "flags": "l",
                       "sType": "1NT ",
-                      "line": "571",
+                      "line": "575",
                       "C": [
                         {
                           "N": "fn",
@@ -8906,7 +8906,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "571",
+                                  "line": "575",
                                   "C": [
                                     { "N": "str", "val": "Web Service: " },
                                     {
@@ -8928,13 +8928,13 @@
                       "name": "Q{}global.binding-name",
                       "bSlot": "1",
                       "sType": "1AS",
-                      "line": "573"
+                      "line": "577"
                     },
                     {
                       "N": "valueOf",
                       "flags": "l",
                       "sType": "1NT ",
-                      "line": "574",
+                      "line": "578",
                       "C": [
                         {
                           "N": "fn",
@@ -8950,7 +8950,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "574",
+                                  "line": "578",
                                   "C": [
                                     { "N": "str", "val": "WS Binding: " },
                                     {
@@ -8970,7 +8970,7 @@
                     {
                       "N": "docOrder",
                       "sType": "*NA nQ{}name",
-                      "line": "576",
+                      "line": "580",
                       "C": [
                         {
                           "N": "slash",
@@ -8996,7 +8996,7 @@
                       "N": "valueOf",
                       "flags": "l",
                       "sType": "1NT ",
-                      "line": "577",
+                      "line": "581",
                       "C": [
                         {
                           "N": "fn",
@@ -9012,7 +9012,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "577",
+                                  "line": "581",
                                   "C": [
                                     { "N": "str", "val": "WS Interface: " },
                                     {
@@ -9095,7 +9095,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "595",
+              "line": "599",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*[local-name(.) = 'documentation']",
@@ -9128,13 +9128,13 @@
                   "N": "choose",
                   "sType": "* ",
                   "role": "action",
-                  "line": "596",
+                  "line": "600",
                   "C": [
                     {
                       "N": "and",
                       "sType": "1AB",
                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                      "line": "596",
+                      "line": "600",
                       "C": [
                         {
                           "N": "gVarRef",
@@ -9173,7 +9173,7 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "597",
+                          "line": "601",
                           "C": [
                             {
                               "N": "sequence",
@@ -9213,7 +9213,7 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "598",
+                          "line": "602",
                           "C": [
                             {
                               "N": "sequence",
@@ -9236,7 +9236,7 @@
                                   "N": "valueOf",
                                   "flags": "d",
                                   "sType": "1NT ",
-                                  "line": "599",
+                                  "line": "603",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -9262,7 +9262,7 @@
                                                           "sType": "1NE",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "599"
+                                                          "line": "603"
                                                         }
                                                       ]
                                                     }
@@ -9326,7 +9326,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "640",
+              "line": "644",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:service|ws2:service",
@@ -9346,7 +9346,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "641",
+                  "line": "645",
                   "C": [
                     {
                       "N": "sequence",
@@ -9367,7 +9367,7 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "642",
+                          "line": "646",
                           "C": [
                             {
                               "N": "sequence",
@@ -9407,7 +9407,7 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "643",
+                          "line": "647",
                           "C": [
                             {
                               "N": "sequence",
@@ -9430,7 +9430,7 @@
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "644",
+                                  "line": "648",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -9455,7 +9455,7 @@
                                                           "N": "docOrder",
                                                           "sType": "*NA nQ{}targetNamespace",
                                                           "role": "select",
-                                                          "line": "644",
+                                                          "line": "648",
                                                           "C": [
                                                             {
                                                               "N": "docOrder",
@@ -9512,7 +9512,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "646",
+                          "line": "650",
                           "mode": "Q{}documentation.render",
                           "bSlot": "1",
                           "C": [
@@ -9521,7 +9521,7 @@
                               "sType": "*NE",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "646",
+                              "line": "650",
                               "C": [
                                 {
                                   "N": "axis",
@@ -9549,7 +9549,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "647",
+                          "line": "651",
                           "mode": "Q{}service",
                           "bSlot": "2",
                           "C": [
@@ -9557,7 +9557,7 @@
                               "N": "docOrder",
                               "sType": "*NE u[NE nQ{http://schemas.xmlsoap.org/wsdl/}port,NE nQ{http://www.w3.org/ns/wsdl}endpoint]",
                               "role": "select",
-                              "line": "647",
+                              "line": "651",
                               "C": [
                                 {
                                   "N": "union",
@@ -9597,7 +9597,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "640",
+              "line": "644",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:service|ws2:service",
@@ -9617,7 +9617,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "641",
+                  "line": "645",
                   "C": [
                     {
                       "N": "sequence",
@@ -9638,7 +9638,7 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "642",
+                          "line": "646",
                           "C": [
                             {
                               "N": "sequence",
@@ -9678,7 +9678,7 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "643",
+                          "line": "647",
                           "C": [
                             {
                               "N": "sequence",
@@ -9701,7 +9701,7 @@
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "644",
+                                  "line": "648",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -9726,7 +9726,7 @@
                                                           "N": "docOrder",
                                                           "sType": "*NA nQ{}targetNamespace",
                                                           "role": "select",
-                                                          "line": "644",
+                                                          "line": "648",
                                                           "C": [
                                                             {
                                                               "N": "docOrder",
@@ -9783,7 +9783,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "646",
+                          "line": "650",
                           "mode": "Q{}documentation.render",
                           "bSlot": "1",
                           "C": [
@@ -9792,7 +9792,7 @@
                               "sType": "*NE",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "646",
+                              "line": "650",
                               "C": [
                                 {
                                   "N": "axis",
@@ -9820,7 +9820,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "647",
+                          "line": "651",
                           "mode": "Q{}service",
                           "bSlot": "2",
                           "C": [
@@ -9828,7 +9828,7 @@
                               "N": "docOrder",
                               "sType": "*NE u[NE nQ{http://schemas.xmlsoap.org/wsdl/}port,NE nQ{http://www.w3.org/ns/wsdl}endpoint]",
                               "role": "select",
-                              "line": "647",
+                              "line": "651",
                               "C": [
                                 {
                                   "N": "union",
@@ -9885,7 +9885,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "814",
+              "line": "818",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:binding|ws2:binding",
@@ -9903,14 +9903,14 @@
                   "var": "Q{}real-binding",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "815",
+                  "line": "819",
                   "role": "action",
                   "C": [
                     {
                       "N": "docOrder",
                       "sType": "*NE",
                       "role": "select",
-                      "line": "815",
+                      "line": "819",
                       "C": [
                         {
                           "N": "union",
@@ -9958,12 +9958,12 @@
                         {
                           "N": "choose",
                           "sType": "* ",
-                          "line": "817",
+                          "line": "821",
                           "C": [
                             {
                               "N": "docOrder",
                               "sType": "*NA nQ{}style",
-                              "line": "817",
+                              "line": "821",
                               "C": [
                                 {
                                   "N": "docOrder",
@@ -10007,7 +10007,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "818",
+                                  "line": "822",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -10047,7 +10047,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "819",
+                                  "line": "823",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -10070,7 +10070,7 @@
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "820",
+                                          "line": "824",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -10095,7 +10095,7 @@
                                                                   "N": "docOrder",
                                                                   "sType": "*NA nQ{}style",
                                                                   "role": "select",
-                                                                  "line": "820",
+                                                                  "line": "824",
                                                                   "C": [
                                                                     {
                                                                       "N": "docOrder",
@@ -10165,12 +10165,12 @@
                         {
                           "N": "choose",
                           "sType": "* ",
-                          "line": "825",
+                          "line": "829",
                           "C": [
                             {
                               "N": "docOrder",
                               "sType": "*N u[NA nQ{}transport,NE]",
-                              "line": "825",
+                              "line": "829",
                               "C": [
                                 {
                                   "N": "union",
@@ -10265,7 +10265,7 @@
                               "var": "Q{}protocol",
                               "slot": "1",
                               "sType": "*NE ",
-                              "line": "827",
+                              "line": "831",
                               "C": [
                                 {
                                   "N": "fn",
@@ -10273,7 +10273,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "827",
+                                  "line": "831",
                                   "C": [
                                     {
                                       "N": "atomSing",
@@ -10391,7 +10391,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "828",
+                                      "line": "832",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -10431,7 +10431,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "829",
+                                      "line": "833",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -10454,7 +10454,7 @@
                                               "N": "choose",
                                               "sType": "?NT ",
                                               "type": "item()*",
-                                              "line": "830",
+                                              "line": "834",
                                               "C": [
                                                 {
                                                   "N": "gc10",
@@ -10463,7 +10463,7 @@
                                                   "card": "1:1",
                                                   "sType": "1AB",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "831",
+                                                  "line": "835",
                                                   "C": [
                                                     {
                                                       "N": "varRef",
@@ -10492,7 +10492,7 @@
                                                   "N": "valueOf",
                                                   "flags": "l",
                                                   "sType": "1NT ",
-                                                  "line": "833",
+                                                  "line": "837",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -10520,7 +10520,7 @@
                                                                           "slot": "1",
                                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                           "role": "select",
-                                                                          "line": "833"
+                                                                          "line": "837"
                                                                         }
                                                                       ]
                                                                     }
@@ -10566,12 +10566,12 @@
                         {
                           "N": "choose",
                           "sType": "* ",
-                          "line": "839",
+                          "line": "843",
                           "C": [
                             {
                               "N": "docOrder",
                               "sType": "*NA nQ{}verb",
-                              "line": "839",
+                              "line": "843",
                               "C": [
                                 {
                                   "N": "docOrder",
@@ -10615,7 +10615,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "840",
+                                  "line": "844",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -10655,7 +10655,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "841",
+                                  "line": "845",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -10678,7 +10678,7 @@
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "842",
+                                          "line": "846",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -10703,7 +10703,7 @@
                                                                   "N": "docOrder",
                                                                   "sType": "*NA nQ{}verb",
                                                                   "role": "select",
-                                                                  "line": "842",
+                                                                  "line": "846",
                                                                   "C": [
                                                                     {
                                                                       "N": "docOrder",
@@ -10786,7 +10786,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "814",
+              "line": "818",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:binding|ws2:binding",
@@ -10804,14 +10804,14 @@
                   "var": "Q{}real-binding",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "815",
+                  "line": "819",
                   "role": "action",
                   "C": [
                     {
                       "N": "docOrder",
                       "sType": "*NE",
                       "role": "select",
-                      "line": "815",
+                      "line": "819",
                       "C": [
                         {
                           "N": "union",
@@ -10859,12 +10859,12 @@
                         {
                           "N": "choose",
                           "sType": "* ",
-                          "line": "817",
+                          "line": "821",
                           "C": [
                             {
                               "N": "docOrder",
                               "sType": "*NA nQ{}style",
-                              "line": "817",
+                              "line": "821",
                               "C": [
                                 {
                                   "N": "docOrder",
@@ -10908,7 +10908,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "818",
+                                  "line": "822",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -10948,7 +10948,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "819",
+                                  "line": "823",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -10971,7 +10971,7 @@
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "820",
+                                          "line": "824",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -10996,7 +10996,7 @@
                                                                   "N": "docOrder",
                                                                   "sType": "*NA nQ{}style",
                                                                   "role": "select",
-                                                                  "line": "820",
+                                                                  "line": "824",
                                                                   "C": [
                                                                     {
                                                                       "N": "docOrder",
@@ -11066,12 +11066,12 @@
                         {
                           "N": "choose",
                           "sType": "* ",
-                          "line": "825",
+                          "line": "829",
                           "C": [
                             {
                               "N": "docOrder",
                               "sType": "*N u[NA nQ{}transport,NE]",
-                              "line": "825",
+                              "line": "829",
                               "C": [
                                 {
                                   "N": "union",
@@ -11166,7 +11166,7 @@
                               "var": "Q{}protocol",
                               "slot": "1",
                               "sType": "*NE ",
-                              "line": "827",
+                              "line": "831",
                               "C": [
                                 {
                                   "N": "fn",
@@ -11174,7 +11174,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "827",
+                                  "line": "831",
                                   "C": [
                                     {
                                       "N": "atomSing",
@@ -11292,7 +11292,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "828",
+                                      "line": "832",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -11332,7 +11332,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "829",
+                                      "line": "833",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -11355,7 +11355,7 @@
                                               "N": "choose",
                                               "sType": "?NT ",
                                               "type": "item()*",
-                                              "line": "830",
+                                              "line": "834",
                                               "C": [
                                                 {
                                                   "N": "gc10",
@@ -11364,7 +11364,7 @@
                                                   "card": "1:1",
                                                   "sType": "1AB",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "831",
+                                                  "line": "835",
                                                   "C": [
                                                     {
                                                       "N": "varRef",
@@ -11393,7 +11393,7 @@
                                                   "N": "valueOf",
                                                   "flags": "l",
                                                   "sType": "1NT ",
-                                                  "line": "833",
+                                                  "line": "837",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -11421,7 +11421,7 @@
                                                                           "slot": "1",
                                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                           "role": "select",
-                                                                          "line": "833"
+                                                                          "line": "837"
                                                                         }
                                                                       ]
                                                                     }
@@ -11467,12 +11467,12 @@
                         {
                           "N": "choose",
                           "sType": "* ",
-                          "line": "839",
+                          "line": "843",
                           "C": [
                             {
                               "N": "docOrder",
                               "sType": "*NA nQ{}verb",
-                              "line": "839",
+                              "line": "843",
                               "C": [
                                 {
                                   "N": "docOrder",
@@ -11516,7 +11516,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "840",
+                                  "line": "844",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -11556,7 +11556,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "841",
+                                  "line": "845",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -11579,7 +11579,7 @@
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "842",
+                                          "line": "846",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -11604,7 +11604,7 @@
                                                                   "N": "docOrder",
                                                                   "sType": "*NA nQ{}verb",
                                                                   "role": "select",
-                                                                  "line": "842",
+                                                                  "line": "846",
                                                                   "C": [
                                                                     {
                                                                       "N": "docOrder",
@@ -11687,7 +11687,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "799",
+              "line": "803",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation|ws2:operation",
@@ -11707,7 +11707,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "800",
+                  "line": "804",
                   "C": [
                     {
                       "N": "sequence",
@@ -11719,7 +11719,7 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}big ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "801",
+                          "line": "805",
                           "C": [
                             {
                               "N": "elem",
@@ -11727,13 +11727,13 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "802",
+                              "line": "806",
                               "C": [
                                 {
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "803",
+                                  "line": "807",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -11761,7 +11761,7 @@
                                                           "nodeTest": "*NA nQ{}name",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "803"
+                                                          "line": "807"
                                                         }
                                                       ]
                                                     }
@@ -11793,14 +11793,14 @@
                         {
                           "N": "choose",
                           "sType": "* ",
-                          "line": "806",
+                          "line": "810",
                           "C": [
                             {
                               "N": "gVarRef",
                               "name": "Q{}ENABLE-LINK",
                               "bSlot": "0",
                               "sType": "* ",
-                              "line": "806"
+                              "line": "810"
                             },
                             {
                               "N": "sequence",
@@ -11809,14 +11809,14 @@
                                 {
                                   "N": "choose",
                                   "sType": "? ",
-                                  "line": "807",
+                                  "line": "811",
                                   "C": [
                                     {
                                       "N": "gVarRef",
                                       "name": "Q{}ENABLE-OPERATIONS-PARAGRAPH",
                                       "bSlot": "1",
                                       "sType": "* ",
-                                      "line": "807"
+                                      "line": "811"
                                     },
                                     {
                                       "N": "elem",
@@ -11824,7 +11824,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "808",
+                                      "line": "812",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -11875,7 +11875,7 @@
                                                                       "name": "concat",
                                                                       "sType": "1AS",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                                      "line": "808",
+                                                                      "line": "812",
                                                                       "C": [
                                                                         {
                                                                           "N": "str",
@@ -11945,7 +11945,7 @@
                                   "bSlot": "3",
                                   "sType": "* ",
                                   "name": "Q{}render.source-code-link",
-                                  "line": "810"
+                                  "line": "814"
                                 }
                               ]
                             },
@@ -11969,7 +11969,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "799",
+              "line": "803",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation|ws2:operation",
@@ -11989,7 +11989,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "800",
+                  "line": "804",
                   "C": [
                     {
                       "N": "sequence",
@@ -12001,7 +12001,7 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}big ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "801",
+                          "line": "805",
                           "C": [
                             {
                               "N": "elem",
@@ -12009,13 +12009,13 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "802",
+                              "line": "806",
                               "C": [
                                 {
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "803",
+                                  "line": "807",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -12043,7 +12043,7 @@
                                                           "nodeTest": "*NA nQ{}name",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "803"
+                                                          "line": "807"
                                                         }
                                                       ]
                                                     }
@@ -12075,14 +12075,14 @@
                         {
                           "N": "choose",
                           "sType": "* ",
-                          "line": "806",
+                          "line": "810",
                           "C": [
                             {
                               "N": "gVarRef",
                               "name": "Q{}ENABLE-LINK",
                               "bSlot": "0",
                               "sType": "* ",
-                              "line": "806"
+                              "line": "810"
                             },
                             {
                               "N": "sequence",
@@ -12091,14 +12091,14 @@
                                 {
                                   "N": "choose",
                                   "sType": "? ",
-                                  "line": "807",
+                                  "line": "811",
                                   "C": [
                                     {
                                       "N": "gVarRef",
                                       "name": "Q{}ENABLE-OPERATIONS-PARAGRAPH",
                                       "bSlot": "1",
                                       "sType": "* ",
-                                      "line": "807"
+                                      "line": "811"
                                     },
                                     {
                                       "N": "elem",
@@ -12106,7 +12106,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "808",
+                                      "line": "812",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -12157,7 +12157,7 @@
                                                                       "name": "concat",
                                                                       "sType": "1AS",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                                      "line": "808",
+                                                                      "line": "812",
                                                                       "C": [
                                                                         {
                                                                           "N": "str",
@@ -12227,7 +12227,7 @@
                                   "bSlot": "3",
                                   "sType": "* ",
                                   "name": "Q{}render.source-code-link",
-                                  "line": "810"
+                                  "line": "814"
                                 }
                               ]
                             },
@@ -12251,7 +12251,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "734",
+              "line": "738",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:port",
@@ -12270,7 +12270,7 @@
                   "var": "Q{}binding-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "735",
+                  "line": "739",
                   "role": "action",
                   "C": [
                     {
@@ -12282,7 +12282,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "736",
+                          "line": "740",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "4",
                           "C": [
@@ -12293,7 +12293,7 @@
                               "sType": "*NA nQ{}binding",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "736"
+                              "line": "740"
                             }
                           ]
                         }
@@ -12304,13 +12304,13 @@
                       "var": "Q{}binding",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "738",
+                      "line": "742",
                       "C": [
                         {
                           "N": "docOrder",
                           "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}binding",
                           "role": "select",
-                          "line": "738",
+                          "line": "742",
                           "C": [
                             {
                               "N": "docOrder",
@@ -12365,7 +12365,7 @@
                           "var": "Q{}binding-uri",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "741",
+                          "line": "745",
                           "C": [
                             {
                               "N": "fn",
@@ -12373,7 +12373,7 @@
                               "sType": "1AU",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "741",
+                              "line": "745",
                               "C": [
                                 {
                                   "N": "first",
@@ -12437,7 +12437,7 @@
                               "var": "Q{}protocol",
                               "slot": "3",
                               "sType": "* ",
-                              "line": "742",
+                              "line": "746",
                               "C": [
                                 {
                                   "N": "doc",
@@ -12449,14 +12449,14 @@
                                       "N": "choose",
                                       "sType": "?NT ",
                                       "type": "item()*",
-                                      "line": "743",
+                                      "line": "747",
                                       "C": [
                                         {
                                           "N": "fn",
                                           "name": "starts-with",
                                           "sType": "1AB",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "744",
+                                          "line": "748",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -12500,7 +12500,7 @@
                                           "name": "starts-with",
                                           "sType": "1AB",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "745",
+                                          "line": "749",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -12544,7 +12544,7 @@
                                           "name": "starts-with",
                                           "sType": "1AB",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "746",
+                                          "line": "750",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -12604,7 +12604,7 @@
                                   "var": "Q{}port-type-name",
                                   "slot": "4",
                                   "sType": "* ",
-                                  "line": "751",
+                                  "line": "755",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -12615,7 +12615,7 @@
                                         {
                                           "N": "applyT",
                                           "sType": "* ",
-                                          "line": "752",
+                                          "line": "756",
                                           "mode": "Q{}qname.normalized",
                                           "bSlot": "4",
                                           "C": [
@@ -12623,7 +12623,7 @@
                                               "N": "docOrder",
                                               "sType": "*NA nQ{}type",
                                               "role": "select",
-                                              "line": "752",
+                                              "line": "756",
                                               "C": [
                                                 {
                                                   "N": "docOrder",
@@ -12666,13 +12666,13 @@
                                       "var": "Q{}port-type",
                                       "slot": "5",
                                       "sType": "* ",
-                                      "line": "756",
+                                      "line": "760",
                                       "C": [
                                         {
                                           "N": "docOrder",
                                           "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}portType",
                                           "role": "select",
-                                          "line": "756",
+                                          "line": "760",
                                           "C": [
                                             {
                                               "N": "docOrder",
@@ -12732,7 +12732,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}h3 ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "759",
+                                              "line": "763",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -12760,7 +12760,7 @@
                                                           "N": "valueOf",
                                                           "flags": "l",
                                                           "sType": "1NT ",
-                                                          "line": "760",
+                                                          "line": "764",
                                                           "C": [
                                                             {
                                                               "N": "fn",
@@ -12788,7 +12788,7 @@
                                                                                   "nodeTest": "*NA nQ{}name",
                                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                                   "role": "select",
-                                                                                  "line": "760"
+                                                                                  "line": "764"
                                                                                 }
                                                                               ]
                                                                             }
@@ -12822,14 +12822,14 @@
                                                     {
                                                       "N": "choose",
                                                       "sType": "* ",
-                                                      "line": "762",
+                                                      "line": "766",
                                                       "C": [
                                                         {
                                                           "N": "gVarRef",
                                                           "name": "Q{}ENABLE-LINK",
                                                           "bSlot": "0",
                                                           "sType": "* ",
-                                                          "line": "762"
+                                                          "line": "766"
                                                         },
                                                         {
                                                           "N": "sequence",
@@ -12852,7 +12852,7 @@
                                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                              "line": "764",
+                                                              "line": "768",
                                                               "C": [
                                                                 {
                                                                   "N": "sequence",
@@ -12861,14 +12861,14 @@
                                                                     {
                                                                       "N": "choose",
                                                                       "sType": "? ",
-                                                                      "line": "765",
+                                                                      "line": "769",
                                                                       "C": [
                                                                         {
                                                                           "N": "gVarRef",
                                                                           "name": "Q{}ENABLE-OPERATIONS-PARAGRAPH",
                                                                           "bSlot": "1",
                                                                           "sType": "* ",
-                                                                          "line": "765"
+                                                                          "line": "769"
                                                                         },
                                                                         {
                                                                           "N": "elem",
@@ -12876,7 +12876,7 @@
                                                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                                          "line": "766",
+                                                                          "line": "770",
                                                                           "C": [
                                                                             {
                                                                               "N": "sequence",
@@ -12937,7 +12937,7 @@
                                                                                                               "name": "concat",
                                                                                                               "sType": "1AS",
                                                                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                                                                              "line": "766",
+                                                                                                              "line": "770",
                                                                                                               "C": [
                                                                                                                 {
                                                                                                                   "N": "atomSing",
@@ -13011,7 +13011,7 @@
                                                                                   "N": "valueOf",
                                                                                   "flags": "l",
                                                                                   "sType": "1NT ",
-                                                                                  "line": "767",
+                                                                                  "line": "771",
                                                                                   "C": [
                                                                                     {
                                                                                       "N": "fn",
@@ -13038,7 +13038,7 @@
                                                                                                           "name": "Q{}PORT-TYPE-TEXT",
                                                                                                           "bSlot": "7",
                                                                                                           "role": "select",
-                                                                                                          "line": "767"
+                                                                                                          "line": "771"
                                                                                                         }
                                                                                                       ]
                                                                                                     }
@@ -13085,7 +13085,7 @@
                                                                       "bSlot": "3",
                                                                       "sType": "* ",
                                                                       "name": "Q{}render.source-code-link",
-                                                                      "line": "770"
+                                                                      "line": "774"
                                                                     }
                                                                   ]
                                                                 }
@@ -13110,7 +13110,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "775",
+                                              "line": "779",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -13150,7 +13150,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "776",
+                                              "line": "780",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -13173,7 +13173,7 @@
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "777",
+                                                      "line": "781",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -13198,7 +13198,7 @@
                                                                               "N": "docOrder",
                                                                               "sType": "*NA nQ{}location",
                                                                               "role": "select",
-                                                                              "line": "777",
+                                                                              "line": "781",
                                                                               "C": [
                                                                                 {
                                                                                   "N": "slash",
@@ -13283,7 +13283,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "780",
+                                              "line": "784",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -13323,7 +13323,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "781",
+                                              "line": "785",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -13346,7 +13346,7 @@
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "782",
+                                                      "line": "786",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -13374,7 +13374,7 @@
                                                                               "slot": "3",
                                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                               "role": "select",
-                                                                              "line": "782"
+                                                                              "line": "786"
                                                                             }
                                                                           ]
                                                                         }
@@ -13410,7 +13410,7 @@
                                             {
                                               "N": "applyT",
                                               "sType": "* ",
-                                              "line": "785",
+                                              "line": "789",
                                               "mode": "Q{}service",
                                               "bSlot": "8",
                                               "C": [
@@ -13421,7 +13421,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "785"
+                                                  "line": "789"
                                                 }
                                               ]
                                             },
@@ -13431,7 +13431,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "787",
+                                              "line": "791",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -13471,7 +13471,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "788",
+                                              "line": "792",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -13507,7 +13507,7 @@
                                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}ol ",
                                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                      "line": "791",
+                                                      "line": "795",
                                                       "C": [
                                                         {
                                                           "N": "sequence",
@@ -13529,7 +13529,7 @@
                                                             {
                                                               "N": "applyT",
                                                               "sType": "* ",
-                                                              "line": "793",
+                                                              "line": "797",
                                                               "mode": "Q{}service",
                                                               "bSlot": "8",
                                                               "C": [
@@ -13542,7 +13542,7 @@
                                                                       "N": "docOrder",
                                                                       "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}operation",
                                                                       "role": "select",
-                                                                      "line": "793",
+                                                                      "line": "797",
                                                                       "C": [
                                                                         {
                                                                           "N": "docOrder",
@@ -13624,7 +13624,7 @@
                                                                                   "sType": "*NA nQ{}name",
                                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                                   "role": "select",
-                                                                                  "line": "794"
+                                                                                  "line": "798"
                                                                                 }
                                                                               ]
                                                                             }
@@ -13694,7 +13694,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "692",
+              "line": "696",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:interface",
@@ -13719,7 +13719,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}h3 ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "693",
+                      "line": "697",
                       "C": [
                         {
                           "N": "sequence",
@@ -13747,7 +13747,7 @@
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "694",
+                                  "line": "698",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -13775,7 +13775,7 @@
                                                           "nodeTest": "*NA nQ{}name",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "694"
+                                                          "line": "698"
                                                         }
                                                       ]
                                                     }
@@ -13805,14 +13805,14 @@
                             {
                               "N": "choose",
                               "sType": "* ",
-                              "line": "696",
+                              "line": "700",
                               "C": [
                                 {
                                   "N": "gVarRef",
                                   "name": "Q{}ENABLE-LINK",
                                   "bSlot": "0",
                                   "sType": "* ",
-                                  "line": "696"
+                                  "line": "700"
                                 },
                                 {
                                   "N": "sequence",
@@ -13835,7 +13835,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "698",
+                                      "line": "702",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -13844,14 +13844,14 @@
                                             {
                                               "N": "choose",
                                               "sType": "? ",
-                                              "line": "699",
+                                              "line": "703",
                                               "C": [
                                                 {
                                                   "N": "gVarRef",
                                                   "name": "Q{}ENABLE-OPERATIONS-PARAGRAPH",
                                                   "bSlot": "1",
                                                   "sType": "* ",
-                                                  "line": "699"
+                                                  "line": "703"
                                                 },
                                                 {
                                                   "N": "elem",
@@ -13859,7 +13859,7 @@
                                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                  "line": "700",
+                                                  "line": "704",
                                                   "C": [
                                                     {
                                                       "N": "sequence",
@@ -13920,7 +13920,7 @@
                                                                                       "name": "concat",
                                                                                       "sType": "1AS",
                                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                                                      "line": "700",
+                                                                                      "line": "704",
                                                                                       "C": [
                                                                                         {
                                                                                           "N": "atomSing",
@@ -13973,7 +13973,7 @@
                                                           "N": "valueOf",
                                                           "flags": "l",
                                                           "sType": "1NT ",
-                                                          "line": "701",
+                                                          "line": "705",
                                                           "C": [
                                                             {
                                                               "N": "fn",
@@ -14000,7 +14000,7 @@
                                                                                   "name": "Q{}PORT-TYPE-TEXT",
                                                                                   "bSlot": "7",
                                                                                   "role": "select",
-                                                                                  "line": "701"
+                                                                                  "line": "705"
                                                                                 }
                                                                               ]
                                                                             }
@@ -14042,7 +14042,7 @@
                                               "bSlot": "3",
                                               "sType": "* ",
                                               "name": "Q{}render.source-code-link",
-                                              "line": "704"
+                                              "line": "708"
                                             }
                                           ]
                                         }
@@ -14063,7 +14063,7 @@
                       "var": "Q{}base-iface-name",
                       "slot": "0",
                       "sType": "* ",
-                      "line": "709",
+                      "line": "713",
                       "C": [
                         {
                           "N": "doc",
@@ -14074,7 +14074,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "710",
+                              "line": "714",
                               "mode": "Q{}qname.normalized",
                               "bSlot": "4",
                               "C": [
@@ -14085,7 +14085,7 @@
                                   "sType": "*NA nQ{}extends",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "710"
+                                  "line": "714"
                                 }
                               ]
                             }
@@ -14098,7 +14098,7 @@
                             {
                               "N": "choose",
                               "sType": "* ",
-                              "line": "713",
+                              "line": "717",
                               "C": [
                                 {
                                   "N": "varRef",
@@ -14106,7 +14106,7 @@
                                   "slot": "0",
                                   "sType": "*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "713"
+                                  "line": "717"
                                 },
                                 {
                                   "N": "sequence",
@@ -14118,7 +14118,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "714",
+                                      "line": "718",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -14158,7 +14158,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "715",
+                                      "line": "719",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -14181,7 +14181,7 @@
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "716",
+                                              "line": "720",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -14209,7 +14209,7 @@
                                                                       "slot": "0",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "716"
+                                                                      "line": "720"
                                                                     }
                                                                   ]
                                                                 }
@@ -14251,13 +14251,13 @@
                               "var": "Q{}base-iface",
                               "slot": "1",
                               "sType": "*NE ",
-                              "line": "721",
+                              "line": "725",
                               "C": [
                                 {
                                   "N": "docOrder",
                                   "sType": "*NE nQ{http://www.w3.org/ns/wsdl}interface",
                                   "role": "select",
-                                  "line": "721",
+                                  "line": "725",
                                   "C": [
                                     {
                                       "N": "docOrder",
@@ -14317,7 +14317,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "723",
+                                      "line": "727",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -14357,7 +14357,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "724",
+                                      "line": "728",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -14393,7 +14393,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}ol ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "727",
+                                              "line": "731",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -14415,7 +14415,7 @@
                                                     {
                                                       "N": "applyT",
                                                       "sType": "* ",
-                                                      "line": "728",
+                                                      "line": "732",
                                                       "mode": "Q{}service",
                                                       "bSlot": "8",
                                                       "C": [
@@ -14428,7 +14428,7 @@
                                                               "N": "docOrder",
                                                               "sType": "*NE nQ{http://www.w3.org/ns/wsdl}operation",
                                                               "role": "select",
-                                                              "line": "728",
+                                                              "line": "732",
                                                               "C": [
                                                                 {
                                                                   "N": "union",
@@ -14494,7 +14494,7 @@
                                                                           "sType": "*NA nQ{}name",
                                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                           "role": "select",
-                                                                          "line": "729"
+                                                                          "line": "733"
                                                                         }
                                                                       ]
                                                                     }
@@ -14560,7 +14560,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "650",
+              "line": "654",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:endpoint",
@@ -14579,7 +14579,7 @@
                   "var": "Q{}binding-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "651",
+                  "line": "655",
                   "role": "action",
                   "C": [
                     {
@@ -14591,7 +14591,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "652",
+                          "line": "656",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "4",
                           "C": [
@@ -14602,7 +14602,7 @@
                               "sType": "*NA nQ{}binding",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "652"
+                              "line": "656"
                             }
                           ]
                         }
@@ -14613,13 +14613,13 @@
                       "var": "Q{}binding",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "654",
+                      "line": "658",
                       "C": [
                         {
                           "N": "docOrder",
                           "sType": "*NE nQ{http://www.w3.org/ns/wsdl}binding",
                           "role": "select",
-                          "line": "654",
+                          "line": "658",
                           "C": [
                             {
                               "N": "docOrder",
@@ -14674,13 +14674,13 @@
                           "var": "Q{}binding-type",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "656",
+                          "line": "660",
                           "C": [
                             {
                               "N": "docOrder",
                               "sType": "*NA nQ{}type",
                               "role": "select",
-                              "line": "656",
+                              "line": "660",
                               "C": [
                                 {
                                   "N": "docOrder",
@@ -14719,13 +14719,13 @@
                               "var": "Q{}binding-protocol",
                               "slot": "3",
                               "sType": "* ",
-                              "line": "657",
+                              "line": "661",
                               "C": [
                                 {
                                   "N": "docOrder",
                                   "sType": "*NA",
                                   "role": "select",
-                                  "line": "657",
+                                  "line": "661",
                                   "C": [
                                     {
                                       "N": "docOrder",
@@ -14786,7 +14786,7 @@
                                   "var": "Q{}protocol",
                                   "slot": "4",
                                   "sType": "* ",
-                                  "line": "658",
+                                  "line": "662",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -14802,14 +14802,14 @@
                                               "N": "choose",
                                               "sType": "?NT ",
                                               "type": "item()*",
-                                              "line": "659",
+                                              "line": "663",
                                               "C": [
                                                 {
                                                   "N": "fn",
                                                   "name": "starts-with",
                                                   "sType": "1AB",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "660",
+                                                  "line": "664",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -14853,7 +14853,7 @@
                                                   "name": "starts-with",
                                                   "sType": "1AB",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "661",
+                                                  "line": "665",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -14897,7 +14897,7 @@
                                                   "name": "starts-with",
                                                   "sType": "1AB",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "662",
+                                                  "line": "666",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -14941,7 +14941,7 @@
                                                   "name": "starts-with",
                                                   "sType": "1AB",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "663",
+                                                  "line": "667",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -14998,14 +14998,14 @@
                                               "N": "choose",
                                               "sType": "? ",
                                               "type": "item()*",
-                                              "line": "668",
+                                              "line": "672",
                                               "C": [
                                                 {
                                                   "N": "fn",
                                                   "name": "starts-with",
                                                   "sType": "1AB",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "669",
+                                                  "line": "673",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -15062,7 +15062,7 @@
                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                          "line": "674",
+                                          "line": "678",
                                           "C": [
                                             {
                                               "N": "sequence",
@@ -15102,7 +15102,7 @@
                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                          "line": "675",
+                                          "line": "679",
                                           "C": [
                                             {
                                               "N": "sequence",
@@ -15125,7 +15125,7 @@
                                                   "N": "valueOf",
                                                   "flags": "l",
                                                   "sType": "1NT ",
-                                                  "line": "676",
+                                                  "line": "680",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -15153,7 +15153,7 @@
                                                                           "nodeTest": "*NA nQ{}address",
                                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                           "role": "select",
-                                                                          "line": "676"
+                                                                          "line": "680"
                                                                         }
                                                                       ]
                                                                     }
@@ -15192,7 +15192,7 @@
                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                          "line": "679",
+                                          "line": "683",
                                           "C": [
                                             {
                                               "N": "sequence",
@@ -15232,7 +15232,7 @@
                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                          "line": "680",
+                                          "line": "684",
                                           "C": [
                                             {
                                               "N": "sequence",
@@ -15255,7 +15255,7 @@
                                                   "N": "valueOf",
                                                   "flags": "l",
                                                   "sType": "1NT ",
-                                                  "line": "681",
+                                                  "line": "685",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -15283,7 +15283,7 @@
                                                                           "slot": "4",
                                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                           "role": "select",
-                                                                          "line": "681"
+                                                                          "line": "685"
                                                                         }
                                                                       ]
                                                                     }
@@ -15319,7 +15319,7 @@
                                         {
                                           "N": "applyT",
                                           "sType": "* ",
-                                          "line": "684",
+                                          "line": "688",
                                           "mode": "Q{}service",
                                           "bSlot": "8",
                                           "C": [
@@ -15330,7 +15330,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "684"
+                                              "line": "688"
                                             }
                                           ]
                                         },
@@ -15339,7 +15339,7 @@
                                           "var": "Q{}iface-name",
                                           "slot": "5",
                                           "sType": "* ",
-                                          "line": "686",
+                                          "line": "690",
                                           "C": [
                                             {
                                               "N": "doc",
@@ -15350,7 +15350,7 @@
                                                 {
                                                   "N": "applyT",
                                                   "sType": "* ",
-                                                  "line": "687",
+                                                  "line": "691",
                                                   "mode": "Q{}qname.normalized",
                                                   "bSlot": "4",
                                                   "C": [
@@ -15358,7 +15358,7 @@
                                                       "N": "docOrder",
                                                       "sType": "*NA nQ{}interface",
                                                       "role": "select",
-                                                      "line": "687",
+                                                      "line": "691",
                                                       "C": [
                                                         {
                                                           "N": "slash",
@@ -15387,7 +15387,7 @@
                                             {
                                               "N": "applyT",
                                               "sType": "* ",
-                                              "line": "689",
+                                              "line": "693",
                                               "mode": "Q{}service",
                                               "bSlot": "8",
                                               "C": [
@@ -15395,7 +15395,7 @@
                                                   "N": "docOrder",
                                                   "sType": "*NE nQ{http://www.w3.org/ns/wsdl}interface",
                                                   "role": "select",
-                                                  "line": "689",
+                                                  "line": "693",
                                                   "C": [
                                                     {
                                                       "N": "docOrder",
@@ -15490,7 +15490,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "960",
+              "line": "964",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation",
@@ -15509,7 +15509,7 @@
                   "var": "Q{}binding-info",
                   "slot": "0",
                   "sType": "*NE ",
-                  "line": "962",
+                  "line": "966",
                   "role": "action",
                   "C": [
                     {
@@ -15518,7 +15518,7 @@
                       "slot": "199",
                       "xpath": "$consolidated-wsdl/ws:binding[@type = current()/../@name or substring-after(@type, ':') = current()/../@name]/ws:operation[@name = current()/@name]",
                       "loc": "xsl:variable/@select",
-                      "line": "962",
+                      "line": "966",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -15722,7 +15722,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}li ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "963",
+                      "line": "967",
                       "C": [
                         {
                           "N": "sequence",
@@ -15731,7 +15731,7 @@
                             {
                               "N": "choose",
                               "sType": "? ",
-                              "line": "964",
+                              "line": "968",
                               "C": [
                                 {
                                   "N": "gc10",
@@ -15740,7 +15740,7 @@
                                   "card": "1:1",
                                   "sType": "1AB",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "964",
+                                  "line": "968",
                                   "C": [
                                     { "N": "fn", "name": "position" },
                                     { "N": "fn", "name": "last" }
@@ -15750,7 +15750,7 @@
                                   "N": "att",
                                   "name": "class",
                                   "sType": "1NA ",
-                                  "line": "965",
+                                  "line": "969",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -15815,7 +15815,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}big ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "967",
+                              "line": "971",
                               "C": [
                                 {
                                   "N": "elem",
@@ -15823,7 +15823,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}b ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "968",
+                                  "line": "972",
                                   "C": [
                                     {
                                       "N": "elem",
@@ -15831,7 +15831,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "969",
+                                      "line": "973",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -15869,7 +15869,7 @@
                                                                       "name": "concat",
                                                                       "sType": "1AS",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                                      "line": "969",
+                                                                      "line": "973",
                                                                       "C": [
                                                                         {
                                                                           "N": "atomSing",
@@ -15915,7 +15915,7 @@
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "970",
+                                              "line": "974",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -15943,7 +15943,7 @@
                                                                       "nodeTest": "*NA nQ{}name",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "970"
+                                                                      "line": "974"
                                                                     }
                                                                   ]
                                                                 }
@@ -15984,7 +15984,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "974",
+                              "line": "978",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -16019,7 +16019,7 @@
                                       "bSlot": "2",
                                       "sType": "* ",
                                       "name": "Q{}render.source-code-link",
-                                      "line": "977"
+                                      "line": "981"
                                     }
                                   ]
                                 }
@@ -16028,13 +16028,13 @@
                             {
                               "N": "choose",
                               "sType": "* ",
-                              "line": "980",
+                              "line": "984",
                               "C": [
                                 {
                                   "N": "and",
                                   "sType": "1AB",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "980",
+                                  "line": "984",
                                   "C": [
                                     {
                                       "N": "gVarRef",
@@ -16084,7 +16084,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "981",
+                                      "line": "985",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -16124,7 +16124,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "982",
+                                      "line": "986",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -16147,7 +16147,7 @@
                                               "N": "valueOf",
                                               "flags": "d",
                                               "sType": "1NT ",
-                                              "line": "983",
+                                              "line": "987",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -16175,7 +16175,7 @@
                                                                       "nodeTest": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}documentation",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "983"
+                                                                      "line": "987"
                                                                     }
                                                                   ]
                                                                 }
@@ -16215,27 +16215,27 @@
                             {
                               "N": "choose",
                               "sType": "* ",
-                              "line": "987",
+                              "line": "991",
                               "C": [
                                 {
                                   "N": "gVarRef",
                                   "name": "Q{}ENABLE-STYLEOPTYPEPATH",
                                   "bSlot": "4",
                                   "sType": "* ",
-                                  "line": "987"
+                                  "line": "991"
                                 },
                                 {
                                   "N": "let",
                                   "var": "Q{}binding-operation",
                                   "slot": "1",
                                   "sType": "* ",
-                                  "line": "988",
+                                  "line": "992",
                                   "C": [
                                     {
                                       "N": "docOrder",
                                       "sType": "*NE",
                                       "role": "select",
-                                      "line": "988",
+                                      "line": "992",
                                       "C": [
                                         {
                                           "N": "docOrder",
@@ -16298,12 +16298,12 @@
                                         {
                                           "N": "choose",
                                           "sType": "* ",
-                                          "line": "989",
+                                          "line": "993",
                                           "C": [
                                             {
                                               "N": "docOrder",
                                               "sType": "*NA nQ{}style",
-                                              "line": "989",
+                                              "line": "993",
                                               "C": [
                                                 {
                                                   "N": "docOrder",
@@ -16347,7 +16347,7 @@
                                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                  "line": "990",
+                                                  "line": "994",
                                                   "C": [
                                                     {
                                                       "N": "sequence",
@@ -16387,7 +16387,7 @@
                                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                  "line": "991",
+                                                  "line": "995",
                                                   "C": [
                                                     {
                                                       "N": "sequence",
@@ -16410,7 +16410,7 @@
                                                           "N": "valueOf",
                                                           "flags": "l",
                                                           "sType": "1NT ",
-                                                          "line": "992",
+                                                          "line": "996",
                                                           "C": [
                                                             {
                                                               "N": "fn",
@@ -16435,7 +16435,7 @@
                                                                                   "N": "docOrder",
                                                                                   "sType": "*NA nQ{}style",
                                                                                   "role": "select",
-                                                                                  "line": "992",
+                                                                                  "line": "996",
                                                                                   "C": [
                                                                                     {
                                                                                       "N": "docOrder",
@@ -16512,7 +16512,7 @@
                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                          "line": "996",
+                                          "line": "1000",
                                           "C": [
                                             {
                                               "N": "sequence",
@@ -16552,7 +16552,7 @@
                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                          "line": "997",
+                                          "line": "1001",
                                           "C": [
                                             {
                                               "N": "sequence",
@@ -16575,12 +16575,12 @@
                                                   "N": "choose",
                                                   "sType": "*N ",
                                                   "type": "item()*",
-                                                  "line": "998",
+                                                  "line": "1002",
                                                   "C": [
                                                     {
                                                       "N": "docOrder",
                                                       "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}input",
-                                                      "line": "999",
+                                                      "line": "1003",
                                                       "C": [
                                                         {
                                                           "N": "docOrder",
@@ -16651,7 +16651,7 @@
                                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                          "line": "1000",
+                                                          "line": "1004",
                                                           "C": [
                                                             {
                                                               "N": "valueOf",
@@ -16682,7 +16682,7 @@
                                                     {
                                                       "N": "docOrder",
                                                       "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}input",
-                                                      "line": "1001",
+                                                      "line": "1005",
                                                       "C": [
                                                         {
                                                           "N": "docOrder",
@@ -16736,7 +16736,7 @@
                                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                          "line": "1002",
+                                                          "line": "1006",
                                                           "C": [
                                                             {
                                                               "N": "valueOf",
@@ -16767,7 +16767,7 @@
                                                     {
                                                       "N": "docOrder",
                                                       "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}input",
-                                                      "line": "1003",
+                                                      "line": "1007",
                                                       "C": [
                                                         {
                                                           "N": "docOrder",
@@ -16827,7 +16827,7 @@
                                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                          "line": "1004",
+                                                          "line": "1008",
                                                           "C": [
                                                             {
                                                               "N": "valueOf",
@@ -16858,7 +16858,7 @@
                                                     {
                                                       "N": "docOrder",
                                                       "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}output",
-                                                      "line": "1005",
+                                                      "line": "1009",
                                                       "C": [
                                                         {
                                                           "N": "docOrder",
@@ -16929,7 +16929,7 @@
                                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                          "line": "1006",
+                                                          "line": "1010",
                                                           "C": [
                                                             {
                                                               "N": "valueOf",
@@ -16978,7 +16978,7 @@
                                         {
                                           "N": "choose",
                                           "sType": "* ",
-                                          "line": "1011",
+                                          "line": "1015",
                                           "C": [
                                             {
                                               "N": "gc10",
@@ -16987,7 +16987,7 @@
                                               "card": "1:1",
                                               "sType": "1AB",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1011",
+                                              "line": "1015",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -17047,7 +17047,7 @@
                                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                  "line": "1012",
+                                                  "line": "1016",
                                                   "C": [
                                                     {
                                                       "N": "sequence",
@@ -17087,7 +17087,7 @@
                                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                  "line": "1013",
+                                                  "line": "1017",
                                                   "C": [
                                                     {
                                                       "N": "sequence",
@@ -17110,7 +17110,7 @@
                                                           "N": "valueOf",
                                                           "flags": "l",
                                                           "sType": "1NT ",
-                                                          "line": "1014",
+                                                          "line": "1018",
                                                           "C": [
                                                             {
                                                               "N": "fn",
@@ -17135,7 +17135,7 @@
                                                                                   "N": "docOrder",
                                                                                   "sType": "*NA nQ{}soapAction",
                                                                                   "role": "select",
-                                                                                  "line": "1014",
+                                                                                  "line": "1018",
                                                                                   "C": [
                                                                                     {
                                                                                       "N": "docOrder",
@@ -17209,12 +17209,12 @@
                                         {
                                           "N": "choose",
                                           "sType": "* ",
-                                          "line": "1018",
+                                          "line": "1022",
                                           "C": [
                                             {
                                               "N": "docOrder",
                                               "sType": "*NA nQ{}location",
-                                              "line": "1018",
+                                              "line": "1022",
                                               "C": [
                                                 {
                                                   "N": "docOrder",
@@ -17258,7 +17258,7 @@
                                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                  "line": "1019",
+                                                  "line": "1023",
                                                   "C": [
                                                     {
                                                       "N": "sequence",
@@ -17298,7 +17298,7 @@
                                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                  "line": "1020",
+                                                  "line": "1024",
                                                   "C": [
                                                     {
                                                       "N": "sequence",
@@ -17321,7 +17321,7 @@
                                                           "N": "valueOf",
                                                           "flags": "l",
                                                           "sType": "1NT ",
-                                                          "line": "1021",
+                                                          "line": "1025",
                                                           "C": [
                                                             {
                                                               "N": "fn",
@@ -17346,7 +17346,7 @@
                                                                                   "N": "docOrder",
                                                                                   "sType": "*NA nQ{}location",
                                                                                   "role": "select",
-                                                                                  "line": "1021",
+                                                                                  "line": "1025",
                                                                                   "C": [
                                                                                     {
                                                                                       "N": "docOrder",
@@ -17428,7 +17428,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "1025",
+                              "line": "1029",
                               "mode": "Q{}operations.message",
                               "bSlot": "5",
                               "C": [
@@ -17436,7 +17436,7 @@
                                   "N": "docOrder",
                                   "sType": "*NE u[NE u[NE nQ{http://schemas.xmlsoap.org/wsdl/}input,NE nQ{http://schemas.xmlsoap.org/wsdl/}output],NE nQ{http://schemas.xmlsoap.org/wsdl/}fault]",
                                   "role": "select",
-                                  "line": "1025",
+                                  "line": "1029",
                                   "C": [
                                     {
                                       "N": "union",
@@ -17482,7 +17482,7 @@
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1026"
+                                      "line": "1030"
                                     }
                                   ]
                                 }
@@ -17506,7 +17506,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "935",
+              "line": "939",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:portType",
@@ -17527,7 +17527,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "936",
+                  "line": "940",
                   "C": [
                     {
                       "N": "sequence",
@@ -17536,7 +17536,7 @@
                         {
                           "N": "choose",
                           "sType": "? ",
-                          "line": "937",
+                          "line": "941",
                           "C": [
                             {
                               "N": "gc10",
@@ -17545,7 +17545,7 @@
                               "card": "1:1",
                               "sType": "1AB",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                              "line": "937",
+                              "line": "941",
                               "C": [
                                 { "N": "fn", "name": "position" },
                                 { "N": "fn", "name": "last" }
@@ -17555,7 +17555,7 @@
                               "N": "att",
                               "name": "class",
                               "sType": "1NA ",
-                              "line": "938",
+                              "line": "942",
                               "C": [
                                 {
                                   "N": "fn",
@@ -17613,14 +17613,14 @@
                         {
                           "N": "choose",
                           "sType": "? ",
-                          "line": "940",
+                          "line": "944",
                           "C": [
                             {
                               "N": "gVarRef",
                               "name": "Q{}ENABLE-PORTTYPE-NAME",
                               "bSlot": "6",
                               "sType": "* ",
-                              "line": "940"
+                              "line": "944"
                             },
                             {
                               "N": "elem",
@@ -17628,7 +17628,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}h3 ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "941",
+                              "line": "945",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -17640,7 +17640,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "942",
+                                      "line": "946",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -17678,7 +17678,7 @@
                                                                       "name": "concat",
                                                                       "sType": "1AS",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                                      "line": "942",
+                                                                      "line": "946",
                                                                       "C": [
                                                                         {
                                                                           "N": "atomSing",
@@ -17724,7 +17724,7 @@
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "943",
+                                              "line": "947",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -17751,7 +17751,7 @@
                                                                       "name": "Q{}PORT-TYPE-TEXT",
                                                                       "bSlot": "8",
                                                                       "role": "select",
-                                                                      "line": "943"
+                                                                      "line": "947"
                                                                     }
                                                                   ]
                                                                 }
@@ -17795,13 +17795,13 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}b ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "946",
+                                              "line": "950",
                                               "C": [
                                                 {
                                                   "N": "valueOf",
                                                   "flags": "l",
                                                   "sType": "1NT ",
-                                                  "line": "947",
+                                                  "line": "951",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -17829,7 +17829,7 @@
                                                                           "nodeTest": "*NA nQ{}name",
                                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                           "role": "select",
-                                                                          "line": "947"
+                                                                          "line": "951"
                                                                         }
                                                                       ]
                                                                     }
@@ -17869,7 +17869,7 @@
                                       "bSlot": "2",
                                       "sType": "* ",
                                       "name": "Q{}render.source-code-link",
-                                      "line": "950"
+                                      "line": "954"
                                     }
                                   ]
                                 }
@@ -17885,12 +17885,12 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}ol ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "953",
+                          "line": "957",
                           "C": [
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "954",
+                              "line": "958",
                               "mode": "Q{}operations",
                               "bSlot": "9",
                               "C": [
@@ -17906,7 +17906,7 @@
                                       "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}operation",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "954"
+                                      "line": "958"
                                     },
                                     {
                                       "N": "sortKey",
@@ -17929,7 +17929,7 @@
                                                   "sType": "*NA nQ{}name",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "955"
+                                                  "line": "959"
                                                 }
                                               ]
                                             }
@@ -17983,7 +17983,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "881",
+              "line": "885",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:operation",
@@ -18002,7 +18002,7 @@
                   "var": "Q{}binding-info",
                   "slot": "0",
                   "sType": "*NE ",
-                  "line": "883",
+                  "line": "887",
                   "role": "action",
                   "C": [
                     {
@@ -18011,7 +18011,7 @@
                       "slot": "199",
                       "xpath": "$consolidated-wsdl/ws2:binding[@interface = current()/../@name or substring-after(@interface, ':') = current()/../@name]/ws2:operation[@ref = current()/@name or substring-after(@ref, ':') = current()/@name]",
                       "loc": "xsl:variable/@select",
-                      "line": "883",
+                      "line": "887",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -18271,7 +18271,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}li ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "884",
+                      "line": "888",
                       "C": [
                         {
                           "N": "sequence",
@@ -18280,7 +18280,7 @@
                             {
                               "N": "choose",
                               "sType": "? ",
-                              "line": "885",
+                              "line": "889",
                               "C": [
                                 {
                                   "N": "gc10",
@@ -18289,7 +18289,7 @@
                                   "card": "1:1",
                                   "sType": "1AB",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "885",
+                                  "line": "889",
                                   "C": [
                                     { "N": "fn", "name": "position" },
                                     { "N": "fn", "name": "last" }
@@ -18299,7 +18299,7 @@
                                   "N": "att",
                                   "name": "class",
                                   "sType": "1NA ",
-                                  "line": "886",
+                                  "line": "890",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -18364,7 +18364,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}big ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "888",
+                              "line": "892",
                               "C": [
                                 {
                                   "N": "elem",
@@ -18372,7 +18372,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}b ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "889",
+                                  "line": "893",
                                   "C": [
                                     {
                                       "N": "elem",
@@ -18380,7 +18380,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "890",
+                                      "line": "894",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -18418,7 +18418,7 @@
                                                                       "name": "concat",
                                                                       "sType": "1AS",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                                      "line": "890",
+                                                                      "line": "894",
                                                                       "C": [
                                                                         {
                                                                           "N": "atomSing",
@@ -18464,7 +18464,7 @@
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "891",
+                                              "line": "895",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -18492,7 +18492,7 @@
                                                                       "nodeTest": "*NA nQ{}name",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "891"
+                                                                      "line": "895"
                                                                     }
                                                                   ]
                                                                 }
@@ -18533,7 +18533,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "895",
+                              "line": "899",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -18568,7 +18568,7 @@
                                       "bSlot": "2",
                                       "sType": "* ",
                                       "name": "Q{}render.source-code-link",
-                                      "line": "898"
+                                      "line": "902"
                                     }
                                   ]
                                 }
@@ -18577,7 +18577,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "900",
+                              "line": "904",
                               "mode": "Q{}documentation.render",
                               "bSlot": "10",
                               "C": [
@@ -18588,21 +18588,21 @@
                                   "sType": "*NE nQ{http://www.w3.org/ns/wsdl}documentation",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "900"
+                                  "line": "904"
                                 }
                               ]
                             },
                             {
                               "N": "choose",
                               "sType": "0 ",
-                              "line": "902",
+                              "line": "906",
                               "C": [
                                 {
                                   "N": "gVarRef",
                                   "name": "Q{}ENABLE-STYLEOPTYPEPATH",
                                   "bSlot": "4",
                                   "sType": "* ",
-                                  "line": "902"
+                                  "line": "906"
                                 },
                                 { "N": "empty", "sType": "0 " },
                                 { "N": "true" },
@@ -18612,7 +18612,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "906",
+                              "line": "910",
                               "mode": "Q{}operations.message",
                               "bSlot": "5",
                               "C": [
@@ -18620,7 +18620,7 @@
                                   "N": "docOrder",
                                   "sType": "*NE u[NE u[NE nQ{http://www.w3.org/ns/wsdl}input,NE nQ{http://www.w3.org/ns/wsdl}output],NE nQ{http://www.w3.org/ns/wsdl}fault]",
                                   "role": "select",
-                                  "line": "906",
+                                  "line": "910",
                                   "C": [
                                     {
                                       "N": "union",
@@ -18745,7 +18745,7 @@
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "907"
+                                      "line": "911"
                                     }
                                   ]
                                 }
@@ -18769,7 +18769,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "860",
+              "line": "864",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:interface",
@@ -18791,14 +18791,14 @@
                     {
                       "N": "choose",
                       "sType": "? ",
-                      "line": "861",
+                      "line": "865",
                       "C": [
                         {
                           "N": "gVarRef",
                           "name": "Q{}ENABLE-PORTTYPE-NAME",
                           "bSlot": "6",
                           "sType": "* ",
-                          "line": "861"
+                          "line": "865"
                         },
                         {
                           "N": "elem",
@@ -18806,7 +18806,7 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}h3 ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "862",
+                          "line": "866",
                           "C": [
                             {
                               "N": "sequence",
@@ -18818,7 +18818,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "863",
+                                  "line": "867",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -18856,7 +18856,7 @@
                                                                   "name": "concat",
                                                                   "sType": "1AS",
                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                                  "line": "863",
+                                                                  "line": "867",
                                                                   "C": [
                                                                     {
                                                                       "N": "atomSing",
@@ -18902,7 +18902,7 @@
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "864",
+                                          "line": "868",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -18929,7 +18929,7 @@
                                                                   "name": "Q{}IFACE-TEXT",
                                                                   "bSlot": "12",
                                                                   "role": "select",
-                                                                  "line": "864"
+                                                                  "line": "868"
                                                                 }
                                                               ]
                                                             }
@@ -18971,13 +18971,13 @@
                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}b ",
                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                          "line": "867",
+                                          "line": "871",
                                           "C": [
                                             {
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "868",
+                                              "line": "872",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -19005,7 +19005,7 @@
                                                                       "nodeTest": "*NA nQ{}name",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "868"
+                                                                      "line": "872"
                                                                     }
                                                                   ]
                                                                 }
@@ -19043,7 +19043,7 @@
                                   "bSlot": "2",
                                   "sType": "* ",
                                   "name": "Q{}render.source-code-link",
-                                  "line": "871"
+                                  "line": "875"
                                 }
                               ]
                             }
@@ -19059,12 +19059,12 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}ol ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "875",
+                      "line": "879",
                       "C": [
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "876",
+                          "line": "880",
                           "mode": "Q{}operations",
                           "bSlot": "9",
                           "C": [
@@ -19080,7 +19080,7 @@
                                   "sType": "*NE nQ{http://www.w3.org/ns/wsdl}operation",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "876"
+                                  "line": "880"
                                 },
                                 {
                                   "N": "sortKey",
@@ -19103,7 +19103,7 @@
                                               "sType": "*NA nQ{}name",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "877"
+                                              "line": "881"
                                             }
                                           ]
                                         }
@@ -19172,7 +19172,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1089",
+              "line": "1093",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:part",
@@ -19193,7 +19193,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "1090",
+                  "line": "1094",
                   "C": [
                     {
                       "N": "sequence",
@@ -19225,7 +19225,7 @@
                           "N": "choose",
                           "sType": "* ",
                           "type": "item()*",
-                          "line": "1091",
+                          "line": "1095",
                           "C": [
                             {
                               "N": "gc10",
@@ -19234,7 +19234,7 @@
                               "card": "1:1",
                               "sType": "1AB",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                              "line": "1092",
+                              "line": "1096",
                               "C": [
                                 {
                                   "N": "fn",
@@ -19271,13 +19271,13 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}b ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "1093",
+                                  "line": "1097",
                                   "C": [
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1094",
+                                      "line": "1098",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -19305,7 +19305,7 @@
                                                               "nodeTest": "*NA nQ{}name",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1094"
+                                                              "line": "1098"
                                                             }
                                                           ]
                                                         }
@@ -19337,7 +19337,7 @@
                                   "var": "Q{}elem-or-type",
                                   "slot": "0",
                                   "sType": "* ",
-                                  "line": "1097",
+                                  "line": "1101",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -19349,7 +19349,7 @@
                                           "N": "choose",
                                           "sType": "?NT ",
                                           "type": "item()*",
-                                          "line": "1098",
+                                          "line": "1102",
                                           "C": [
                                             {
                                               "N": "axis",
@@ -19357,13 +19357,13 @@
                                               "nodeTest": "*NA nQ{}type",
                                               "sType": "*NA nQ{}type",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1099"
+                                              "line": "1103"
                                             },
                                             {
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1100",
+                                              "line": "1104",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -19391,7 +19391,7 @@
                                                                       "nodeTest": "*NA nQ{}type",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1100"
+                                                                      "line": "1104"
                                                                     }
                                                                   ]
                                                                 }
@@ -19423,7 +19423,7 @@
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1103",
+                                              "line": "1107",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -19451,7 +19451,7 @@
                                                                       "nodeTest": "*NA nQ{}element",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1103"
+                                                                      "line": "1107"
                                                                     }
                                                                   ]
                                                                 }
@@ -19487,7 +19487,7 @@
                                       "var": "Q{}type-local-name",
                                       "slot": "1",
                                       "sType": "* ",
-                                      "line": "1108",
+                                      "line": "1112",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -19495,7 +19495,7 @@
                                           "sType": "1AS",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1108",
+                                          "line": "1112",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -19525,7 +19525,7 @@
                                           "var": "Q{}type-name",
                                           "slot": "2",
                                           "sType": "* ",
-                                          "line": "1109",
+                                          "line": "1113",
                                           "C": [
                                             {
                                               "N": "doc",
@@ -19537,7 +19537,7 @@
                                                   "N": "choose",
                                                   "sType": "?NT ",
                                                   "type": "item()*",
-                                                  "line": "1110",
+                                                  "line": "1114",
                                                   "C": [
                                                     {
                                                       "N": "varRef",
@@ -19545,13 +19545,13 @@
                                                       "slot": "1",
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                      "line": "1111"
+                                                      "line": "1115"
                                                     },
                                                     {
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "1112",
+                                                      "line": "1116",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -19579,7 +19579,7 @@
                                                                               "slot": "1",
                                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                               "role": "select",
-                                                                              "line": "1112"
+                                                                              "line": "1116"
                                                                             }
                                                                           ]
                                                                         }
@@ -19614,13 +19614,13 @@
                                                       "slot": "0",
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                      "line": "1114"
+                                                      "line": "1118"
                                                     },
                                                     {
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "1115",
+                                                      "line": "1119",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -19648,7 +19648,7 @@
                                                                               "slot": "0",
                                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                               "role": "select",
-                                                                              "line": "1115"
+                                                                              "line": "1119"
                                                                             }
                                                                           ]
                                                                         }
@@ -19702,7 +19702,7 @@
                                                   "bSlot": "0",
                                                   "sType": "* ",
                                                   "name": "Q{}render-type",
-                                                  "line": "1121",
+                                                  "line": "1125",
                                                   "C": [
                                                     {
                                                       "N": "withParam",
@@ -19717,7 +19717,7 @@
                                                           "sType": "*",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1122"
+                                                          "line": "1126"
                                                         }
                                                       ]
                                                     }
@@ -19728,14 +19728,14 @@
                                                   "var": "Q{}part-type",
                                                   "slot": "3",
                                                   "sType": "* ",
-                                                  "line": "1126",
+                                                  "line": "1130",
                                                   "C": [
                                                     {
                                                       "N": "first",
                                                       "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1126",
+                                                      "line": "1130",
                                                       "C": [
                                                         {
                                                           "N": "filter",
@@ -19786,7 +19786,7 @@
                                                     {
                                                       "N": "applyT",
                                                       "sType": "* ",
-                                                      "line": "1127",
+                                                      "line": "1131",
                                                       "mode": "Q{}operations.message.part",
                                                       "bSlot": "2",
                                                       "C": [
@@ -19797,7 +19797,7 @@
                                                           "sType": "*",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1127"
+                                                          "line": "1131"
                                                         }
                                                       ]
                                                     }
@@ -19820,7 +19820,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "1131",
+                              "line": "1135",
                               "C": [
                                 {
                                   "N": "valueOf",
@@ -19853,7 +19853,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1065",
+              "line": "1069",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:message",
@@ -19879,7 +19879,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1066",
+                      "line": "1070",
                       "C": [
                         {
                           "N": "str",
@@ -19901,7 +19901,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "1067",
+                      "line": "1071",
                       "C": [
                         {
                           "N": "sequence",
@@ -19920,7 +19920,7 @@
                               "N": "valueOf",
                               "flags": "l",
                               "sType": "1NT ",
-                              "line": "1068",
+                              "line": "1072",
                               "C": [
                                 {
                                   "N": "fn",
@@ -19948,7 +19948,7 @@
                                                       "nodeTest": "*NA nQ{}name",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1068"
+                                                      "line": "1072"
                                                     }
                                                   ]
                                                 }
@@ -19972,7 +19972,7 @@
                             {
                               "N": "choose",
                               "sType": "* ",
-                              "line": "1069",
+                              "line": "1073",
                               "C": [
                                 {
                                   "N": "varRef",
@@ -19980,7 +19980,7 @@
                                   "slot": "0",
                                   "sType": "*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1069"
+                                  "line": "1073"
                                 },
                                 {
                                   "N": "sequence",
@@ -20001,7 +20001,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1071",
+                                      "line": "1075",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -20017,7 +20017,7 @@
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1071",
+                                                  "line": "1075",
                                                   "C": [
                                                     {
                                                       "N": "treat",
@@ -20061,13 +20061,13 @@
                                       "var": "Q{}use",
                                       "slot": "1",
                                       "sType": "* ",
-                                      "line": "1072",
+                                      "line": "1076",
                                       "C": [
                                         {
                                           "N": "docOrder",
                                           "sType": "*NA nQ{}use",
                                           "role": "select",
-                                          "line": "1072",
+                                          "line": "1076",
                                           "C": [
                                             {
                                               "N": "docOrder",
@@ -20108,7 +20108,7 @@
                                             {
                                               "N": "choose",
                                               "sType": "* ",
-                                              "line": "1073",
+                                              "line": "1077",
                                               "C": [
                                                 {
                                                   "N": "varRef",
@@ -20116,7 +20116,7 @@
                                                   "slot": "1",
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                  "line": "1073"
+                                                  "line": "1077"
                                                 },
                                                 {
                                                   "N": "sequence",
@@ -20137,7 +20137,7 @@
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "1075",
+                                                      "line": "1079",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -20165,7 +20165,7 @@
                                                                               "slot": "1",
                                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                               "role": "select",
-                                                                              "line": "1075"
+                                                                              "line": "1079"
                                                                             }
                                                                           ]
                                                                         }
@@ -20205,13 +20205,13 @@
                                               "var": "Q{}part",
                                               "slot": "2",
                                               "sType": "* ",
-                                              "line": "1077",
+                                              "line": "1081",
                                               "C": [
                                                 {
                                                   "N": "docOrder",
                                                   "sType": "*NA nQ{}part",
                                                   "role": "select",
-                                                  "line": "1077",
+                                                  "line": "1081",
                                                   "C": [
                                                     {
                                                       "N": "docOrder",
@@ -20252,7 +20252,7 @@
                                                     {
                                                       "N": "choose",
                                                       "sType": "* ",
-                                                      "line": "1078",
+                                                      "line": "1082",
                                                       "C": [
                                                         {
                                                           "N": "varRef",
@@ -20260,7 +20260,7 @@
                                                           "slot": "2",
                                                           "sType": "*",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                          "line": "1078"
+                                                          "line": "1082"
                                                         },
                                                         {
                                                           "N": "sequence",
@@ -20281,7 +20281,7 @@
                                                               "N": "valueOf",
                                                               "flags": "l",
                                                               "sType": "1NT ",
-                                                              "line": "1080",
+                                                              "line": "1084",
                                                               "C": [
                                                                 {
                                                                   "N": "fn",
@@ -20309,7 +20309,7 @@
                                                                                       "slot": "2",
                                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                                       "role": "select",
-                                                                                      "line": "1080"
+                                                                                      "line": "1084"
                                                                                     }
                                                                                   ]
                                                                                 }
@@ -20377,7 +20377,7 @@
                               "bSlot": "3",
                               "sType": "* ",
                               "name": "Q{}render.source-code-link",
-                              "line": "1084"
+                              "line": "1088"
                             }
                           ]
                         }
@@ -20386,7 +20386,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1087",
+                      "line": "1091",
                       "mode": "Q{}operations.message",
                       "bSlot": "4",
                       "C": [
@@ -20397,7 +20397,7 @@
                           "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}part",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1087"
+                          "line": "1091"
                         }
                       ]
                     }
@@ -20415,7 +20415,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1030",
+              "line": "1034",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:input|ws:output|ws:fault",
@@ -20440,7 +20440,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1031",
+                      "line": "1035",
                       "C": [
                         {
                           "N": "str",
@@ -20459,14 +20459,14 @@
                     {
                       "N": "choose",
                       "sType": "* ",
-                      "line": "1032",
+                      "line": "1036",
                       "C": [
                         {
                           "N": "gVarRef",
                           "name": "Q{}ENABLE-INOUTFAULT",
                           "bSlot": "5",
                           "sType": "* ",
-                          "line": "1032"
+                          "line": "1036"
                         },
                         {
                           "N": "sequence",
@@ -20478,7 +20478,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "1033",
+                              "line": "1037",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -20501,7 +20501,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1034",
+                                      "line": "1038",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -20517,7 +20517,7 @@
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1034",
+                                                  "line": "1038",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -20610,7 +20610,7 @@
                               "var": "Q{}msg-local-name",
                               "slot": "1",
                               "sType": "* ",
-                              "line": "1037",
+                              "line": "1041",
                               "C": [
                                 {
                                   "N": "fn",
@@ -20618,7 +20618,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1037",
+                                  "line": "1041",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -20648,7 +20648,7 @@
                                   "var": "Q{}msg-name",
                                   "slot": "2",
                                   "sType": "* ",
-                                  "line": "1038",
+                                  "line": "1042",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -20660,7 +20660,7 @@
                                           "N": "choose",
                                           "sType": "?NT ",
                                           "type": "item()*",
-                                          "line": "1039",
+                                          "line": "1043",
                                           "C": [
                                             {
                                               "N": "varRef",
@@ -20668,13 +20668,13 @@
                                               "slot": "1",
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1040"
+                                              "line": "1044"
                                             },
                                             {
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1041",
+                                              "line": "1045",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -20702,7 +20702,7 @@
                                                                       "slot": "1",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1041"
+                                                                      "line": "1045"
                                                                     }
                                                                   ]
                                                                 }
@@ -20734,7 +20734,7 @@
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1044",
+                                              "line": "1048",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -20762,7 +20762,7 @@
                                                                       "nodeTest": "*NA nQ{}message",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1044"
+                                                                      "line": "1048"
                                                                     }
                                                                   ]
                                                                 }
@@ -20798,13 +20798,13 @@
                                       "var": "Q{}msg",
                                       "slot": "3",
                                       "sType": "* ",
-                                      "line": "1049",
+                                      "line": "1053",
                                       "C": [
                                         {
                                           "N": "docOrder",
                                           "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}message",
                                           "role": "select",
-                                          "line": "1049",
+                                          "line": "1053",
                                           "C": [
                                             {
                                               "N": "docOrder",
@@ -20858,7 +20858,7 @@
                                           "N": "choose",
                                           "sType": "* ",
                                           "type": "item()*",
-                                          "line": "1050",
+                                          "line": "1054",
                                           "C": [
                                             {
                                               "N": "varRef",
@@ -20866,12 +20866,12 @@
                                               "slot": "3",
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1051"
+                                              "line": "1055"
                                             },
                                             {
                                               "N": "applyT",
                                               "sType": "* ",
-                                              "line": "1052",
+                                              "line": "1056",
                                               "mode": "Q{}operations.message",
                                               "bSlot": "4",
                                               "C": [
@@ -20882,7 +20882,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1052"
+                                                  "line": "1056"
                                                 },
                                                 {
                                                   "N": "withParam",
@@ -20896,7 +20896,7 @@
                                                       "slot": "199",
                                                       "xpath": "$binding-data/ws:*[local-name(.) = local-name(current())]/*",
                                                       "loc": "xsl:with-param/@select",
-                                                      "line": "1054",
+                                                      "line": "1058",
                                                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                                                       "role": "select",
                                                       "BC": "true",
@@ -20996,7 +20996,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "1058",
+                                              "line": "1062",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -21021,7 +21021,7 @@
                                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                      "line": "1059",
+                                                      "line": "1063",
                                                       "C": [
                                                         {
                                                           "N": "valueOf",
@@ -21068,7 +21068,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1030",
+              "line": "1034",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:input|ws:output|ws:fault",
@@ -21093,7 +21093,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1031",
+                      "line": "1035",
                       "C": [
                         {
                           "N": "str",
@@ -21112,14 +21112,14 @@
                     {
                       "N": "choose",
                       "sType": "* ",
-                      "line": "1032",
+                      "line": "1036",
                       "C": [
                         {
                           "N": "gVarRef",
                           "name": "Q{}ENABLE-INOUTFAULT",
                           "bSlot": "5",
                           "sType": "* ",
-                          "line": "1032"
+                          "line": "1036"
                         },
                         {
                           "N": "sequence",
@@ -21131,7 +21131,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "1033",
+                              "line": "1037",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -21154,7 +21154,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1034",
+                                      "line": "1038",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -21170,7 +21170,7 @@
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1034",
+                                                  "line": "1038",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -21263,7 +21263,7 @@
                               "var": "Q{}msg-local-name",
                               "slot": "1",
                               "sType": "* ",
-                              "line": "1037",
+                              "line": "1041",
                               "C": [
                                 {
                                   "N": "fn",
@@ -21271,7 +21271,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1037",
+                                  "line": "1041",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -21301,7 +21301,7 @@
                                   "var": "Q{}msg-name",
                                   "slot": "2",
                                   "sType": "* ",
-                                  "line": "1038",
+                                  "line": "1042",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -21313,7 +21313,7 @@
                                           "N": "choose",
                                           "sType": "?NT ",
                                           "type": "item()*",
-                                          "line": "1039",
+                                          "line": "1043",
                                           "C": [
                                             {
                                               "N": "varRef",
@@ -21321,13 +21321,13 @@
                                               "slot": "1",
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1040"
+                                              "line": "1044"
                                             },
                                             {
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1041",
+                                              "line": "1045",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -21355,7 +21355,7 @@
                                                                       "slot": "1",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1041"
+                                                                      "line": "1045"
                                                                     }
                                                                   ]
                                                                 }
@@ -21387,7 +21387,7 @@
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1044",
+                                              "line": "1048",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -21415,7 +21415,7 @@
                                                                       "nodeTest": "*NA nQ{}message",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1044"
+                                                                      "line": "1048"
                                                                     }
                                                                   ]
                                                                 }
@@ -21451,13 +21451,13 @@
                                       "var": "Q{}msg",
                                       "slot": "3",
                                       "sType": "* ",
-                                      "line": "1049",
+                                      "line": "1053",
                                       "C": [
                                         {
                                           "N": "docOrder",
                                           "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}message",
                                           "role": "select",
-                                          "line": "1049",
+                                          "line": "1053",
                                           "C": [
                                             {
                                               "N": "docOrder",
@@ -21511,7 +21511,7 @@
                                           "N": "choose",
                                           "sType": "* ",
                                           "type": "item()*",
-                                          "line": "1050",
+                                          "line": "1054",
                                           "C": [
                                             {
                                               "N": "varRef",
@@ -21519,12 +21519,12 @@
                                               "slot": "3",
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1051"
+                                              "line": "1055"
                                             },
                                             {
                                               "N": "applyT",
                                               "sType": "* ",
-                                              "line": "1052",
+                                              "line": "1056",
                                               "mode": "Q{}operations.message",
                                               "bSlot": "4",
                                               "C": [
@@ -21535,7 +21535,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1052"
+                                                  "line": "1056"
                                                 },
                                                 {
                                                   "N": "withParam",
@@ -21549,7 +21549,7 @@
                                                       "slot": "199",
                                                       "xpath": "$binding-data/ws:*[local-name(.) = local-name(current())]/*",
                                                       "loc": "xsl:with-param/@select",
-                                                      "line": "1054",
+                                                      "line": "1058",
                                                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                                                       "role": "select",
                                                       "BC": "true",
@@ -21649,7 +21649,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "1058",
+                                              "line": "1062",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -21674,7 +21674,7 @@
                                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                      "line": "1059",
+                                                      "line": "1063",
                                                       "C": [
                                                         {
                                                           "N": "valueOf",
@@ -21721,7 +21721,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1030",
+              "line": "1034",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:input|ws:output|ws:fault",
@@ -21746,7 +21746,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1031",
+                      "line": "1035",
                       "C": [
                         {
                           "N": "str",
@@ -21765,14 +21765,14 @@
                     {
                       "N": "choose",
                       "sType": "* ",
-                      "line": "1032",
+                      "line": "1036",
                       "C": [
                         {
                           "N": "gVarRef",
                           "name": "Q{}ENABLE-INOUTFAULT",
                           "bSlot": "5",
                           "sType": "* ",
-                          "line": "1032"
+                          "line": "1036"
                         },
                         {
                           "N": "sequence",
@@ -21784,7 +21784,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "1033",
+                              "line": "1037",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -21807,7 +21807,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1034",
+                                      "line": "1038",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -21823,7 +21823,7 @@
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1034",
+                                                  "line": "1038",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -21916,7 +21916,7 @@
                               "var": "Q{}msg-local-name",
                               "slot": "1",
                               "sType": "* ",
-                              "line": "1037",
+                              "line": "1041",
                               "C": [
                                 {
                                   "N": "fn",
@@ -21924,7 +21924,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1037",
+                                  "line": "1041",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -21954,7 +21954,7 @@
                                   "var": "Q{}msg-name",
                                   "slot": "2",
                                   "sType": "* ",
-                                  "line": "1038",
+                                  "line": "1042",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -21966,7 +21966,7 @@
                                           "N": "choose",
                                           "sType": "?NT ",
                                           "type": "item()*",
-                                          "line": "1039",
+                                          "line": "1043",
                                           "C": [
                                             {
                                               "N": "varRef",
@@ -21974,13 +21974,13 @@
                                               "slot": "1",
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1040"
+                                              "line": "1044"
                                             },
                                             {
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1041",
+                                              "line": "1045",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -22008,7 +22008,7 @@
                                                                       "slot": "1",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1041"
+                                                                      "line": "1045"
                                                                     }
                                                                   ]
                                                                 }
@@ -22040,7 +22040,7 @@
                                               "N": "valueOf",
                                               "flags": "l",
                                               "sType": "1NT ",
-                                              "line": "1044",
+                                              "line": "1048",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -22068,7 +22068,7 @@
                                                                       "nodeTest": "*NA nQ{}message",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1044"
+                                                                      "line": "1048"
                                                                     }
                                                                   ]
                                                                 }
@@ -22104,13 +22104,13 @@
                                       "var": "Q{}msg",
                                       "slot": "3",
                                       "sType": "* ",
-                                      "line": "1049",
+                                      "line": "1053",
                                       "C": [
                                         {
                                           "N": "docOrder",
                                           "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}message",
                                           "role": "select",
-                                          "line": "1049",
+                                          "line": "1053",
                                           "C": [
                                             {
                                               "N": "docOrder",
@@ -22164,7 +22164,7 @@
                                           "N": "choose",
                                           "sType": "* ",
                                           "type": "item()*",
-                                          "line": "1050",
+                                          "line": "1054",
                                           "C": [
                                             {
                                               "N": "varRef",
@@ -22172,12 +22172,12 @@
                                               "slot": "3",
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1051"
+                                              "line": "1055"
                                             },
                                             {
                                               "N": "applyT",
                                               "sType": "* ",
-                                              "line": "1052",
+                                              "line": "1056",
                                               "mode": "Q{}operations.message",
                                               "bSlot": "4",
                                               "C": [
@@ -22188,7 +22188,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1052"
+                                                  "line": "1056"
                                                 },
                                                 {
                                                   "N": "withParam",
@@ -22202,7 +22202,7 @@
                                                       "slot": "199",
                                                       "xpath": "$binding-data/ws:*[local-name(.) = local-name(current())]/*",
                                                       "loc": "xsl:with-param/@select",
-                                                      "line": "1054",
+                                                      "line": "1058",
                                                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                                                       "role": "select",
                                                       "BC": "true",
@@ -22302,7 +22302,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "1058",
+                                              "line": "1062",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -22327,7 +22327,7 @@
                                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                      "line": "1059",
+                                                      "line": "1063",
                                                       "C": [
                                                         {
                                                           "N": "valueOf",
@@ -22374,7 +22374,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "911",
+              "line": "915",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:input|ws2:output|ws2:fault",
@@ -22399,7 +22399,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "912",
+                      "line": "916",
                       "C": [
                         {
                           "N": "str",
@@ -22418,14 +22418,14 @@
                     {
                       "N": "choose",
                       "sType": "* ",
-                      "line": "913",
+                      "line": "917",
                       "C": [
                         {
                           "N": "gVarRef",
                           "name": "Q{}ENABLE-INOUTFAULT",
                           "bSlot": "5",
                           "sType": "* ",
-                          "line": "913"
+                          "line": "917"
                         },
                         {
                           "N": "sequence",
@@ -22437,7 +22437,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "914",
+                              "line": "918",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -22460,7 +22460,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "915",
+                                      "line": "919",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -22476,7 +22476,7 @@
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "915",
+                                                  "line": "919",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -22570,7 +22570,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "918",
+                              "line": "922",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -22594,7 +22594,7 @@
                                       "var": "Q{}type-name",
                                       "slot": "1",
                                       "sType": "* ",
-                                      "line": "919",
+                                      "line": "923",
                                       "C": [
                                         {
                                           "N": "doc",
@@ -22605,7 +22605,7 @@
                                             {
                                               "N": "applyT",
                                               "sType": "* ",
-                                              "line": "920",
+                                              "line": "924",
                                               "mode": "Q{}qname.normalized",
                                               "bSlot": "7",
                                               "C": [
@@ -22616,7 +22616,7 @@
                                                   "sType": "*NA nQ{}element",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "920"
+                                                  "line": "924"
                                                 }
                                               ]
                                             }
@@ -22631,7 +22631,7 @@
                                               "bSlot": "0",
                                               "sType": "* ",
                                               "name": "Q{}render-type",
-                                              "line": "923",
+                                              "line": "927",
                                               "C": [
                                                 {
                                                   "N": "withParam",
@@ -22646,7 +22646,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "924"
+                                                      "line": "928"
                                                     }
                                                   ]
                                                 }
@@ -22657,21 +22657,21 @@
                                               "bSlot": "3",
                                               "sType": "* ",
                                               "name": "Q{}render.source-code-link",
-                                              "line": "927"
+                                              "line": "931"
                                             },
                                             {
                                               "N": "let",
                                               "var": "Q{}type-tree",
                                               "slot": "2",
                                               "sType": "* ",
-                                              "line": "930",
+                                              "line": "934",
                                               "C": [
                                                 {
                                                   "N": "first",
                                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "930",
+                                                  "line": "934",
                                                   "C": [
                                                     {
                                                       "N": "filter",
@@ -22722,7 +22722,7 @@
                                                 {
                                                   "N": "applyT",
                                                   "sType": "* ",
-                                                  "line": "931",
+                                                  "line": "935",
                                                   "mode": "Q{}operations.message.part",
                                                   "bSlot": "2",
                                                   "C": [
@@ -22733,7 +22733,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "931"
+                                                      "line": "935"
                                                     }
                                                   ]
                                                 }
@@ -22767,7 +22767,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "911",
+              "line": "915",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:input|ws2:output|ws2:fault",
@@ -22792,7 +22792,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "912",
+                      "line": "916",
                       "C": [
                         {
                           "N": "str",
@@ -22811,14 +22811,14 @@
                     {
                       "N": "choose",
                       "sType": "* ",
-                      "line": "913",
+                      "line": "917",
                       "C": [
                         {
                           "N": "gVarRef",
                           "name": "Q{}ENABLE-INOUTFAULT",
                           "bSlot": "5",
                           "sType": "* ",
-                          "line": "913"
+                          "line": "917"
                         },
                         {
                           "N": "sequence",
@@ -22830,7 +22830,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "914",
+                              "line": "918",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -22853,7 +22853,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "915",
+                                      "line": "919",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -22869,7 +22869,7 @@
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "915",
+                                                  "line": "919",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -22963,7 +22963,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "918",
+                              "line": "922",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -22987,7 +22987,7 @@
                                       "var": "Q{}type-name",
                                       "slot": "1",
                                       "sType": "* ",
-                                      "line": "919",
+                                      "line": "923",
                                       "C": [
                                         {
                                           "N": "doc",
@@ -22998,7 +22998,7 @@
                                             {
                                               "N": "applyT",
                                               "sType": "* ",
-                                              "line": "920",
+                                              "line": "924",
                                               "mode": "Q{}qname.normalized",
                                               "bSlot": "7",
                                               "C": [
@@ -23009,7 +23009,7 @@
                                                   "sType": "*NA nQ{}element",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "920"
+                                                  "line": "924"
                                                 }
                                               ]
                                             }
@@ -23024,7 +23024,7 @@
                                               "bSlot": "0",
                                               "sType": "* ",
                                               "name": "Q{}render-type",
-                                              "line": "923",
+                                              "line": "927",
                                               "C": [
                                                 {
                                                   "N": "withParam",
@@ -23039,7 +23039,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "924"
+                                                      "line": "928"
                                                     }
                                                   ]
                                                 }
@@ -23050,21 +23050,21 @@
                                               "bSlot": "3",
                                               "sType": "* ",
                                               "name": "Q{}render.source-code-link",
-                                              "line": "927"
+                                              "line": "931"
                                             },
                                             {
                                               "N": "let",
                                               "var": "Q{}type-tree",
                                               "slot": "2",
                                               "sType": "* ",
-                                              "line": "930",
+                                              "line": "934",
                                               "C": [
                                                 {
                                                   "N": "first",
                                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "930",
+                                                  "line": "934",
                                                   "C": [
                                                     {
                                                       "N": "filter",
@@ -23115,7 +23115,7 @@
                                                 {
                                                   "N": "applyT",
                                                   "sType": "* ",
-                                                  "line": "931",
+                                                  "line": "935",
                                                   "mode": "Q{}operations.message.part",
                                                   "bSlot": "2",
                                                   "C": [
@@ -23126,7 +23126,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "931"
+                                                      "line": "935"
                                                     }
                                                   ]
                                                 }
@@ -23160,7 +23160,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "911",
+              "line": "915",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:input|ws2:output|ws2:fault",
@@ -23185,7 +23185,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "912",
+                      "line": "916",
                       "C": [
                         {
                           "N": "str",
@@ -23204,14 +23204,14 @@
                     {
                       "N": "choose",
                       "sType": "* ",
-                      "line": "913",
+                      "line": "917",
                       "C": [
                         {
                           "N": "gVarRef",
                           "name": "Q{}ENABLE-INOUTFAULT",
                           "bSlot": "5",
                           "sType": "* ",
-                          "line": "913"
+                          "line": "917"
                         },
                         {
                           "N": "sequence",
@@ -23223,7 +23223,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "914",
+                              "line": "918",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -23246,7 +23246,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "915",
+                                      "line": "919",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -23262,7 +23262,7 @@
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "915",
+                                                  "line": "919",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -23356,7 +23356,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "918",
+                              "line": "922",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -23380,7 +23380,7 @@
                                       "var": "Q{}type-name",
                                       "slot": "1",
                                       "sType": "* ",
-                                      "line": "919",
+                                      "line": "923",
                                       "C": [
                                         {
                                           "N": "doc",
@@ -23391,7 +23391,7 @@
                                             {
                                               "N": "applyT",
                                               "sType": "* ",
-                                              "line": "920",
+                                              "line": "924",
                                               "mode": "Q{}qname.normalized",
                                               "bSlot": "7",
                                               "C": [
@@ -23402,7 +23402,7 @@
                                                   "sType": "*NA nQ{}element",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "920"
+                                                  "line": "924"
                                                 }
                                               ]
                                             }
@@ -23417,7 +23417,7 @@
                                               "bSlot": "0",
                                               "sType": "* ",
                                               "name": "Q{}render-type",
-                                              "line": "923",
+                                              "line": "927",
                                               "C": [
                                                 {
                                                   "N": "withParam",
@@ -23432,7 +23432,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "924"
+                                                      "line": "928"
                                                     }
                                                   ]
                                                 }
@@ -23443,21 +23443,21 @@
                                               "bSlot": "3",
                                               "sType": "* ",
                                               "name": "Q{}render.source-code-link",
-                                              "line": "927"
+                                              "line": "931"
                                             },
                                             {
                                               "N": "let",
                                               "var": "Q{}type-tree",
                                               "slot": "2",
                                               "sType": "* ",
-                                              "line": "930",
+                                              "line": "934",
                                               "C": [
                                                 {
                                                   "N": "first",
                                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "930",
+                                                  "line": "934",
                                                   "C": [
                                                     {
                                                       "N": "filter",
@@ -23508,7 +23508,7 @@
                                                 {
                                                   "N": "applyT",
                                                   "sType": "* ",
-                                                  "line": "931",
+                                                  "line": "935",
                                                   "mode": "Q{}operations.message.part",
                                                   "bSlot": "2",
                                                   "C": [
@@ -23519,7 +23519,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "931"
+                                                      "line": "935"
                                                     }
                                                   ]
                                                 }
@@ -23570,7 +23570,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1399",
+              "line": "1403",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:attribute[ @*[local-name() = 'arrayType'] ]",
@@ -23620,7 +23620,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1400",
+                      "line": "1404",
                       "C": [
                         {
                           "N": "str",
@@ -23641,7 +23641,7 @@
                       "var": "Q{}array-local-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1402",
+                      "line": "1406",
                       "C": [
                         {
                           "N": "fn",
@@ -23649,7 +23649,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1402",
+                          "line": "1406",
                           "C": [
                             {
                               "N": "fn",
@@ -23698,7 +23698,7 @@
                           "var": "Q{}type-local-name",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1403",
+                          "line": "1407",
                           "C": [
                             {
                               "N": "fn",
@@ -23706,7 +23706,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1403",
+                              "line": "1407",
                               "C": [
                                 {
                                   "N": "fn",
@@ -23736,14 +23736,14 @@
                               "var": "Q{}array-type",
                               "slot": "3",
                               "sType": "* ",
-                              "line": "1404",
+                              "line": "1408",
                               "C": [
                                 {
                                   "N": "first",
                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1404",
+                                  "line": "1408",
                                   "C": [
                                     {
                                       "N": "filter",
@@ -23780,7 +23780,7 @@
                                   "var": "Q{}recursion.label",
                                   "slot": "4",
                                   "sType": "* ",
-                                  "line": "1406",
+                                  "line": "1410",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -23788,7 +23788,7 @@
                                       "sType": "1AS",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1406",
+                                      "line": "1410",
                                       "C": [
                                         { "N": "str", "val": "[" },
                                         {
@@ -23816,7 +23816,7 @@
                                       "var": "Q{}recursion.test",
                                       "slot": "5",
                                       "sType": "* ",
-                                      "line": "1407",
+                                      "line": "1411",
                                       "C": [
                                         {
                                           "N": "doc",
@@ -23829,7 +23829,7 @@
                                               "bSlot": "1",
                                               "sType": "* ",
                                               "name": "Q{}recursion.should.continue",
-                                              "line": "1408",
+                                              "line": "1412",
                                               "C": [
                                                 {
                                                   "N": "withParam",
@@ -23844,7 +23844,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1409"
+                                                      "line": "1413"
                                                     }
                                                   ]
                                                 },
@@ -23861,7 +23861,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1410"
+                                                      "line": "1414"
                                                     }
                                                   ]
                                                 }
@@ -23873,7 +23873,7 @@
                                           "N": "choose",
                                           "sType": "* ",
                                           "type": "item()*",
-                                          "line": "1414",
+                                          "line": "1418",
                                           "C": [
                                             {
                                               "N": "gc10",
@@ -23882,7 +23882,7 @@
                                               "card": "1:1",
                                               "sType": "1AB",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1415",
+                                              "line": "1419",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -23912,7 +23912,7 @@
                                             {
                                               "N": "applyT",
                                               "sType": "* ",
-                                              "line": "1416",
+                                              "line": "1420",
                                               "mode": "Q{}operations.message.part",
                                               "bSlot": "2",
                                               "C": [
@@ -23923,7 +23923,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1416"
+                                                  "line": "1420"
                                                 },
                                                 {
                                                   "N": "withParam",
@@ -23937,7 +23937,7 @@
                                                       "sType": "1AS",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1417",
+                                                      "line": "1421",
                                                       "C": [
                                                         {
                                                           "N": "atomSing",
@@ -23986,7 +23986,7 @@
                                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                                               "nsuri": "http://www.w3.org/1999/xhtml",
                                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                                              "line": "1421",
+                                              "line": "1425",
                                               "C": [
                                                 {
                                                   "N": "sequence",
@@ -24009,7 +24009,7 @@
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "1422",
+                                                      "line": "1426",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -24036,7 +24036,7 @@
                                                                               "name": "Q{}RECURSIVE",
                                                                               "bSlot": "3",
                                                                               "role": "select",
-                                                                              "line": "1422"
+                                                                              "line": "1426"
                                                                             }
                                                                           ]
                                                                         }
@@ -24095,7 +24095,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1318",
+              "line": "1322",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:element[parent::xsd:schema]",
@@ -24131,7 +24131,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1319",
+                      "line": "1323",
                       "C": [
                         {
                           "N": "str",
@@ -24152,7 +24152,7 @@
                       "var": "Q{}recursion.label",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1320",
+                      "line": "1324",
                       "C": [
                         {
                           "N": "fn",
@@ -24160,7 +24160,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1320",
+                          "line": "1324",
                           "C": [
                             { "N": "str", "val": "[" },
                             {
@@ -24188,7 +24188,7 @@
                           "var": "Q{}recursion.test",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1321",
+                          "line": "1325",
                           "C": [
                             {
                               "N": "doc",
@@ -24201,7 +24201,7 @@
                                   "bSlot": "1",
                                   "sType": "* ",
                                   "name": "Q{}recursion.should.continue",
-                                  "line": "1322",
+                                  "line": "1326",
                                   "C": [
                                     {
                                       "N": "withParam",
@@ -24216,7 +24216,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1323"
+                                          "line": "1327"
                                         }
                                       ]
                                     },
@@ -24233,7 +24233,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1324"
+                                          "line": "1328"
                                         }
                                       ]
                                     }
@@ -24245,7 +24245,7 @@
                               "N": "choose",
                               "sType": "* ",
                               "type": "item()*",
-                              "line": "1328",
+                              "line": "1332",
                               "C": [
                                 {
                                   "N": "gc10",
@@ -24254,7 +24254,7 @@
                                   "card": "1:1",
                                   "sType": "1AB",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1329",
+                                  "line": "1333",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -24286,7 +24286,7 @@
                                   "var": "Q{}type-name",
                                   "slot": "3",
                                   "sType": "* ",
-                                  "line": "1330",
+                                  "line": "1334",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -24299,7 +24299,7 @@
                                           "bSlot": "4",
                                           "sType": "* ",
                                           "name": "Q{}xsd.element-type",
-                                          "line": "1331"
+                                          "line": "1335"
                                         }
                                       ]
                                     },
@@ -24308,7 +24308,7 @@
                                       "var": "Q{}elem-type",
                                       "slot": "4",
                                       "sType": "* ",
-                                      "line": "1334",
+                                      "line": "1338",
                                       "C": [
                                         {
                                           "N": "let",
@@ -24316,7 +24316,7 @@
                                           "slot": "199",
                                           "xpath": "$consolidated-xsd[generate-id() != generate-id(current()) and $type-name and @name=$type-name and contains(local-name(), 'Type')][1]",
                                           "loc": "xsl:variable/@select",
-                                          "line": "1334",
+                                          "line": "1338",
                                           "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                                           "role": "select",
                                           "BC": "true",
@@ -24432,7 +24432,7 @@
                                         {
                                           "N": "choose",
                                           "sType": "* ",
-                                          "line": "1336",
+                                          "line": "1340",
                                           "C": [
                                             {
                                               "N": "gc10",
@@ -24441,7 +24441,7 @@
                                               "card": "1:1",
                                               "sType": "1AB",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1336",
+                                              "line": "1340",
                                               "C": [
                                                 {
                                                   "N": "varRef",
@@ -24462,7 +24462,7 @@
                                                 {
                                                   "N": "applyT",
                                                   "sType": "* ",
-                                                  "line": "1337",
+                                                  "line": "1341",
                                                   "mode": "Q{}operations.message.part",
                                                   "bSlot": "2",
                                                   "C": [
@@ -24473,7 +24473,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1337"
+                                                      "line": "1341"
                                                     },
                                                     {
                                                       "N": "withParam",
@@ -24487,7 +24487,7 @@
                                                           "sType": "1AS",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1338",
+                                                          "line": "1342",
                                                           "C": [
                                                             {
                                                               "N": "atomSing",
@@ -24532,14 +24532,14 @@
                                                 {
                                                   "N": "choose",
                                                   "sType": "* ",
-                                                  "line": "1341",
+                                                  "line": "1345",
                                                   "C": [
                                                     {
                                                       "N": "fn",
                                                       "name": "not",
                                                       "sType": "1AB",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                      "line": "1341",
+                                                      "line": "1345",
                                                       "C": [
                                                         {
                                                           "N": "varRef",
@@ -24553,7 +24553,7 @@
                                                       "bSlot": "5",
                                                       "sType": "* ",
                                                       "name": "Q{}render-type",
-                                                      "line": "1342",
+                                                      "line": "1346",
                                                       "C": [
                                                         {
                                                           "N": "withParam",
@@ -24568,7 +24568,7 @@
                                                               "sType": "*",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1343"
+                                                              "line": "1347"
                                                             }
                                                           ]
                                                         }
@@ -24584,7 +24584,7 @@
                                                 {
                                                   "N": "applyT",
                                                   "sType": "* ",
-                                                  "line": "1347",
+                                                  "line": "1351",
                                                   "mode": "Q{}operations.message.part",
                                                   "bSlot": "2",
                                                   "C": [
@@ -24595,7 +24595,7 @@
                                                       "sType": "*NE",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1347"
+                                                      "line": "1351"
                                                     },
                                                     {
                                                       "N": "withParam",
@@ -24609,7 +24609,7 @@
                                                           "sType": "1AS",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1348",
+                                                          "line": "1352",
                                                           "C": [
                                                             {
                                                               "N": "atomSing",
@@ -24668,7 +24668,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "1353",
+                                  "line": "1357",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -24691,7 +24691,7 @@
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1354",
+                                          "line": "1358",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -24718,7 +24718,7 @@
                                                                   "name": "Q{}RECURSIVE",
                                                                   "bSlot": "3",
                                                                   "role": "select",
-                                                                  "line": "1354"
+                                                                  "line": "1358"
                                                                 }
                                                               ]
                                                             }
@@ -24767,7 +24767,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1207",
+              "line": "1211",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:complexType[descendant::xsd:attribute[ not(@*[local-name() = 'arrayType']) ]]",
@@ -24837,7 +24837,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1208",
+                      "line": "1212",
                       "C": [
                         {
                           "N": "str",
@@ -24858,7 +24858,7 @@
                       "var": "Q{}recursion.label",
                       "slot": "1",
                       "sType": "*NE ",
-                      "line": "1209",
+                      "line": "1213",
                       "C": [
                         {
                           "N": "fn",
@@ -24866,7 +24866,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1209",
+                          "line": "1213",
                           "C": [
                             { "N": "str", "val": "[" },
                             {
@@ -24894,7 +24894,7 @@
                           "var": "Q{}recursion.test",
                           "slot": "2",
                           "sType": "*NE ",
-                          "line": "1210",
+                          "line": "1214",
                           "C": [
                             {
                               "N": "doc",
@@ -24907,7 +24907,7 @@
                                   "bSlot": "1",
                                   "sType": "* ",
                                   "name": "Q{}recursion.should.continue",
-                                  "line": "1211",
+                                  "line": "1215",
                                   "C": [
                                     {
                                       "N": "withParam",
@@ -24922,7 +24922,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1212"
+                                          "line": "1216"
                                         }
                                       ]
                                     },
@@ -24939,7 +24939,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1213"
+                                          "line": "1217"
                                         }
                                       ]
                                     }
@@ -24951,7 +24951,7 @@
                               "N": "choose",
                               "sType": "?NE ",
                               "type": "item()*",
-                              "line": "1217",
+                              "line": "1221",
                               "C": [
                                 {
                                   "N": "gc10",
@@ -24960,7 +24960,7 @@
                                   "card": "1:1",
                                   "sType": "1AB",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1218",
+                                  "line": "1222",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -24993,7 +24993,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}ul ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "1219",
+                                  "line": "1223",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -25015,7 +25015,7 @@
                                         {
                                           "N": "applyT",
                                           "sType": "* ",
-                                          "line": "1220",
+                                          "line": "1224",
                                           "mode": "Q{}operations.message.part",
                                           "bSlot": "2",
                                           "C": [
@@ -25026,7 +25026,7 @@
                                               "sType": "*NE",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1220"
+                                              "line": "1224"
                                             },
                                             {
                                               "N": "withParam",
@@ -25040,7 +25040,7 @@
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1221",
+                                                  "line": "1225",
                                                   "C": [
                                                     {
                                                       "N": "atomSing",
@@ -25093,7 +25093,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "1226",
+                                  "line": "1230",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -25116,7 +25116,7 @@
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1227",
+                                          "line": "1231",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -25143,7 +25143,7 @@
                                                                   "name": "Q{}RECURSIVE",
                                                                   "bSlot": "3",
                                                                   "role": "select",
-                                                                  "line": "1227"
+                                                                  "line": "1231"
                                                                 }
                                                               ]
                                                             }
@@ -25192,7 +25192,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1453",
+              "line": "1457",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:documentation",
@@ -25213,7 +25213,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "1454",
+                  "line": "1458",
                   "C": [
                     {
                       "N": "sequence",
@@ -25236,7 +25236,7 @@
                           "N": "valueOf",
                           "flags": "d",
                           "sType": "1NT ",
-                          "line": "1455",
+                          "line": "1459",
                           "C": [
                             {
                               "N": "fn",
@@ -25262,7 +25262,7 @@
                                                   "sType": "1NE nQ{http://www.w3.org/2001/XMLSchema}documentation",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1455"
+                                                  "line": "1459"
                                                 }
                                               ]
                                             }
@@ -25299,7 +25299,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1360",
+              "line": "1364",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:element | xsd:attribute",
@@ -25324,7 +25324,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1361",
+                      "line": "1365",
                       "C": [
                         {
                           "N": "str",
@@ -25346,14 +25346,14 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}li ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "1365",
+                      "line": "1369",
                       "C": [
                         {
                           "N": "let",
                           "var": "Q{}local-ref",
                           "slot": "1",
                           "sType": "* ",
-                          "line": "1366",
+                          "line": "1370",
                           "C": [
                             {
                               "N": "fn",
@@ -25361,7 +25361,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1366",
+                              "line": "1370",
                               "C": [
                                 {
                                   "N": "atomSing",
@@ -25414,7 +25414,7 @@
                               "var": "Q{}elem-name",
                               "slot": "2",
                               "sType": "* ",
-                              "line": "1367",
+                              "line": "1371",
                               "C": [
                                 {
                                   "N": "doc",
@@ -25426,7 +25426,7 @@
                                       "N": "choose",
                                       "sType": "?NT ",
                                       "type": "item()*",
-                                      "line": "1368",
+                                      "line": "1372",
                                       "C": [
                                         {
                                           "N": "axis",
@@ -25434,13 +25434,13 @@
                                           "nodeTest": "*NA nQ{}name",
                                           "sType": "*NA nQ{}name",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "1369"
+                                          "line": "1373"
                                         },
                                         {
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1370",
+                                          "line": "1374",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -25468,7 +25468,7 @@
                                                                   "nodeTest": "*NA nQ{}name",
                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                   "role": "select",
-                                                                  "line": "1370"
+                                                                  "line": "1374"
                                                                 }
                                                               ]
                                                             }
@@ -25499,13 +25499,13 @@
                                           "slot": "1",
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "1372"
+                                          "line": "1376"
                                         },
                                         {
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1373",
+                                          "line": "1377",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -25533,7 +25533,7 @@
                                                                   "slot": "1",
                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                   "role": "select",
-                                                                  "line": "1373"
+                                                                  "line": "1377"
                                                                 }
                                                               ]
                                                             }
@@ -25564,13 +25564,13 @@
                                           "nodeTest": "*NA nQ{}ref",
                                           "sType": "*NA nQ{}ref",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "1375"
+                                          "line": "1379"
                                         },
                                         {
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1376",
+                                          "line": "1380",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -25598,7 +25598,7 @@
                                                                   "nodeTest": "*NA nQ{}ref",
                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                   "role": "select",
-                                                                  "line": "1376"
+                                                                  "line": "1380"
                                                                 }
                                                               ]
                                                             }
@@ -25647,7 +25647,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1381",
+                                      "line": "1385",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -25675,7 +25675,7 @@
                                                               "slot": "2",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1381"
+                                                              "line": "1385"
                                                             }
                                                           ]
                                                         }
@@ -25705,7 +25705,7 @@
                                       "var": "Q{}type-name",
                                       "slot": "3",
                                       "sType": "* ",
-                                      "line": "1383",
+                                      "line": "1387",
                                       "C": [
                                         {
                                           "N": "doc",
@@ -25718,7 +25718,7 @@
                                               "bSlot": "4",
                                               "sType": "* ",
                                               "name": "Q{}xsd.element-type",
-                                              "line": "1384"
+                                              "line": "1388"
                                             }
                                           ]
                                         },
@@ -25731,7 +25731,7 @@
                                               "bSlot": "5",
                                               "sType": "* ",
                                               "name": "Q{}render-type",
-                                              "line": "1387",
+                                              "line": "1391",
                                               "C": [
                                                 {
                                                   "N": "withParam",
@@ -25746,7 +25746,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1388"
+                                                      "line": "1392"
                                                     }
                                                   ]
                                                 }
@@ -25757,14 +25757,14 @@
                                               "var": "Q{}elem-type",
                                               "slot": "4",
                                               "sType": "* ",
-                                              "line": "1392",
+                                              "line": "1396",
                                               "C": [
                                                 {
                                                   "N": "first",
                                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1392",
+                                                  "line": "1396",
                                                   "C": [
                                                     {
                                                       "N": "filter",
@@ -25827,7 +25827,7 @@
                                                 {
                                                   "N": "applyT",
                                                   "sType": "* ",
-                                                  "line": "1393",
+                                                  "line": "1397",
                                                   "mode": "Q{}operations.message.part",
                                                   "bSlot": "2",
                                                   "C": [
@@ -25837,7 +25837,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1393",
+                                                      "line": "1397",
                                                       "C": [
                                                         {
                                                           "N": "docOrder",
@@ -25876,7 +25876,7 @@
                                                           "sType": "*",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1394"
+                                                          "line": "1398"
                                                         }
                                                       ]
                                                     }
@@ -25910,7 +25910,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1360",
+              "line": "1364",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:element | xsd:attribute",
@@ -25935,7 +25935,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1361",
+                      "line": "1365",
                       "C": [
                         {
                           "N": "str",
@@ -25957,14 +25957,14 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}li ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "1365",
+                      "line": "1369",
                       "C": [
                         {
                           "N": "let",
                           "var": "Q{}local-ref",
                           "slot": "1",
                           "sType": "* ",
-                          "line": "1366",
+                          "line": "1370",
                           "C": [
                             {
                               "N": "fn",
@@ -25972,7 +25972,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1366",
+                              "line": "1370",
                               "C": [
                                 {
                                   "N": "atomSing",
@@ -26025,7 +26025,7 @@
                               "var": "Q{}elem-name",
                               "slot": "2",
                               "sType": "* ",
-                              "line": "1367",
+                              "line": "1371",
                               "C": [
                                 {
                                   "N": "doc",
@@ -26037,7 +26037,7 @@
                                       "N": "choose",
                                       "sType": "?NT ",
                                       "type": "item()*",
-                                      "line": "1368",
+                                      "line": "1372",
                                       "C": [
                                         {
                                           "N": "axis",
@@ -26045,13 +26045,13 @@
                                           "nodeTest": "*NA nQ{}name",
                                           "sType": "*NA nQ{}name",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "1369"
+                                          "line": "1373"
                                         },
                                         {
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1370",
+                                          "line": "1374",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -26079,7 +26079,7 @@
                                                                   "nodeTest": "*NA nQ{}name",
                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                   "role": "select",
-                                                                  "line": "1370"
+                                                                  "line": "1374"
                                                                 }
                                                               ]
                                                             }
@@ -26110,13 +26110,13 @@
                                           "slot": "1",
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "1372"
+                                          "line": "1376"
                                         },
                                         {
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1373",
+                                          "line": "1377",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -26144,7 +26144,7 @@
                                                                   "slot": "1",
                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                   "role": "select",
-                                                                  "line": "1373"
+                                                                  "line": "1377"
                                                                 }
                                                               ]
                                                             }
@@ -26175,13 +26175,13 @@
                                           "nodeTest": "*NA nQ{}ref",
                                           "sType": "*NA nQ{}ref",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "1375"
+                                          "line": "1379"
                                         },
                                         {
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1376",
+                                          "line": "1380",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -26209,7 +26209,7 @@
                                                                   "nodeTest": "*NA nQ{}ref",
                                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                   "role": "select",
-                                                                  "line": "1376"
+                                                                  "line": "1380"
                                                                 }
                                                               ]
                                                             }
@@ -26258,7 +26258,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1381",
+                                      "line": "1385",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -26286,7 +26286,7 @@
                                                               "slot": "2",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1381"
+                                                              "line": "1385"
                                                             }
                                                           ]
                                                         }
@@ -26316,7 +26316,7 @@
                                       "var": "Q{}type-name",
                                       "slot": "3",
                                       "sType": "* ",
-                                      "line": "1383",
+                                      "line": "1387",
                                       "C": [
                                         {
                                           "N": "doc",
@@ -26329,7 +26329,7 @@
                                               "bSlot": "4",
                                               "sType": "* ",
                                               "name": "Q{}xsd.element-type",
-                                              "line": "1384"
+                                              "line": "1388"
                                             }
                                           ]
                                         },
@@ -26342,7 +26342,7 @@
                                               "bSlot": "5",
                                               "sType": "* ",
                                               "name": "Q{}render-type",
-                                              "line": "1387",
+                                              "line": "1391",
                                               "C": [
                                                 {
                                                   "N": "withParam",
@@ -26357,7 +26357,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1388"
+                                                      "line": "1392"
                                                     }
                                                   ]
                                                 }
@@ -26368,14 +26368,14 @@
                                               "var": "Q{}elem-type",
                                               "slot": "4",
                                               "sType": "* ",
-                                              "line": "1392",
+                                              "line": "1396",
                                               "C": [
                                                 {
                                                   "N": "first",
                                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1392",
+                                                  "line": "1396",
                                                   "C": [
                                                     {
                                                       "N": "filter",
@@ -26438,7 +26438,7 @@
                                                 {
                                                   "N": "applyT",
                                                   "sType": "* ",
-                                                  "line": "1393",
+                                                  "line": "1397",
                                                   "mode": "Q{}operations.message.part",
                                                   "bSlot": "2",
                                                   "C": [
@@ -26448,7 +26448,7 @@
                                                       "sType": "*",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1393",
+                                                      "line": "1397",
                                                       "C": [
                                                         {
                                                           "N": "docOrder",
@@ -26487,7 +26487,7 @@
                                                           "sType": "*",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1394"
+                                                          "line": "1398"
                                                         }
                                                       ]
                                                     }
@@ -26521,7 +26521,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1299",
+              "line": "1303",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:all|xsd:any|xsd:choice",
@@ -26546,7 +26546,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1300",
+                      "line": "1304",
                       "C": [
                         {
                           "N": "str",
@@ -26567,7 +26567,7 @@
                       "var": "Q{}list-type",
                       "slot": "1",
                       "sType": "*NE ",
-                      "line": "1301",
+                      "line": "1305",
                       "C": [
                         {
                           "N": "doc",
@@ -26579,7 +26579,7 @@
                               "N": "choose",
                               "sType": "?NT ",
                               "type": "item()*",
-                              "line": "1302",
+                              "line": "1306",
                               "C": [
                                 {
                                   "N": "axis",
@@ -26587,7 +26587,7 @@
                                   "nodeTest": "*NE nQ{http://www.w3.org/2001/XMLSchema}all",
                                   "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}all",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1303"
+                                  "line": "1307"
                                 },
                                 {
                                   "N": "valueOf",
@@ -26606,7 +26606,7 @@
                                   "nodeTest": "*NE nQ{http://www.w3.org/2001/XMLSchema}any",
                                   "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}any",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1304"
+                                  "line": "1308"
                                 },
                                 {
                                   "N": "valueOf",
@@ -26641,7 +26641,7 @@
                           "name": "ul",
                           "sType": "1NE ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
-                          "line": "1309",
+                          "line": "1313",
                           "C": [
                             {
                               "N": "sequence",
@@ -26651,7 +26651,7 @@
                                   "N": "att",
                                   "name": "style",
                                   "sType": "1NA ",
-                                  "line": "1310",
+                                  "line": "1314",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -26676,7 +26676,7 @@
                                                           "N": "valueOf",
                                                           "sType": "1NT ",
                                                           "flags": "l",
-                                                          "line": "1311",
+                                                          "line": "1315",
                                                           "C": [
                                                             {
                                                               "N": "fn",
@@ -26692,7 +26692,7 @@
                                                                       "sType": "1AS",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1311",
+                                                                      "line": "1315",
                                                                       "C": [
                                                                         {
                                                                           "N": "str",
@@ -26754,7 +26754,7 @@
                                 {
                                   "N": "applyT",
                                   "sType": "* ",
-                                  "line": "1313",
+                                  "line": "1317",
                                   "mode": "Q{}operations.message.part",
                                   "bSlot": "2",
                                   "C": [
@@ -26765,7 +26765,7 @@
                                       "sType": "*NE",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1313"
+                                      "line": "1317"
                                     },
                                     {
                                       "N": "withParam",
@@ -26780,7 +26780,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1314"
+                                          "line": "1318"
                                         }
                                       ]
                                     }
@@ -26806,7 +26806,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1299",
+              "line": "1303",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:all|xsd:any|xsd:choice",
@@ -26831,7 +26831,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1300",
+                      "line": "1304",
                       "C": [
                         {
                           "N": "str",
@@ -26852,7 +26852,7 @@
                       "var": "Q{}list-type",
                       "slot": "1",
                       "sType": "*NE ",
-                      "line": "1301",
+                      "line": "1305",
                       "C": [
                         {
                           "N": "doc",
@@ -26864,7 +26864,7 @@
                               "N": "choose",
                               "sType": "?NT ",
                               "type": "item()*",
-                              "line": "1302",
+                              "line": "1306",
                               "C": [
                                 {
                                   "N": "axis",
@@ -26872,7 +26872,7 @@
                                   "nodeTest": "*NE nQ{http://www.w3.org/2001/XMLSchema}all",
                                   "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}all",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1303"
+                                  "line": "1307"
                                 },
                                 {
                                   "N": "valueOf",
@@ -26891,7 +26891,7 @@
                                   "nodeTest": "*NE nQ{http://www.w3.org/2001/XMLSchema}any",
                                   "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}any",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1304"
+                                  "line": "1308"
                                 },
                                 {
                                   "N": "valueOf",
@@ -26926,7 +26926,7 @@
                           "name": "ul",
                           "sType": "1NE ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
-                          "line": "1309",
+                          "line": "1313",
                           "C": [
                             {
                               "N": "sequence",
@@ -26936,7 +26936,7 @@
                                   "N": "att",
                                   "name": "style",
                                   "sType": "1NA ",
-                                  "line": "1310",
+                                  "line": "1314",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -26961,7 +26961,7 @@
                                                           "N": "valueOf",
                                                           "sType": "1NT ",
                                                           "flags": "l",
-                                                          "line": "1311",
+                                                          "line": "1315",
                                                           "C": [
                                                             {
                                                               "N": "fn",
@@ -26977,7 +26977,7 @@
                                                                       "sType": "1AS",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1311",
+                                                                      "line": "1315",
                                                                       "C": [
                                                                         {
                                                                           "N": "str",
@@ -27039,7 +27039,7 @@
                                 {
                                   "N": "applyT",
                                   "sType": "* ",
-                                  "line": "1313",
+                                  "line": "1317",
                                   "mode": "Q{}operations.message.part",
                                   "bSlot": "2",
                                   "C": [
@@ -27050,7 +27050,7 @@
                                       "sType": "*NE",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1313"
+                                      "line": "1317"
                                     },
                                     {
                                       "N": "withParam",
@@ -27065,7 +27065,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1314"
+                                          "line": "1318"
                                         }
                                       ]
                                     }
@@ -27091,7 +27091,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1299",
+              "line": "1303",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:all|xsd:any|xsd:choice",
@@ -27116,7 +27116,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1300",
+                      "line": "1304",
                       "C": [
                         {
                           "N": "str",
@@ -27137,7 +27137,7 @@
                       "var": "Q{}list-type",
                       "slot": "1",
                       "sType": "*NE ",
-                      "line": "1301",
+                      "line": "1305",
                       "C": [
                         {
                           "N": "doc",
@@ -27149,7 +27149,7 @@
                               "N": "choose",
                               "sType": "?NT ",
                               "type": "item()*",
-                              "line": "1302",
+                              "line": "1306",
                               "C": [
                                 {
                                   "N": "axis",
@@ -27157,7 +27157,7 @@
                                   "nodeTest": "*NE nQ{http://www.w3.org/2001/XMLSchema}all",
                                   "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}all",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1303"
+                                  "line": "1307"
                                 },
                                 {
                                   "N": "valueOf",
@@ -27176,7 +27176,7 @@
                                   "nodeTest": "*NE nQ{http://www.w3.org/2001/XMLSchema}any",
                                   "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}any",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1304"
+                                  "line": "1308"
                                 },
                                 {
                                   "N": "valueOf",
@@ -27211,7 +27211,7 @@
                           "name": "ul",
                           "sType": "1NE ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
-                          "line": "1309",
+                          "line": "1313",
                           "C": [
                             {
                               "N": "sequence",
@@ -27221,7 +27221,7 @@
                                   "N": "att",
                                   "name": "style",
                                   "sType": "1NA ",
-                                  "line": "1310",
+                                  "line": "1314",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -27246,7 +27246,7 @@
                                                           "N": "valueOf",
                                                           "sType": "1NT ",
                                                           "flags": "l",
-                                                          "line": "1311",
+                                                          "line": "1315",
                                                           "C": [
                                                             {
                                                               "N": "fn",
@@ -27262,7 +27262,7 @@
                                                                       "sType": "1AS",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                       "role": "select",
-                                                                      "line": "1311",
+                                                                      "line": "1315",
                                                                       "C": [
                                                                         {
                                                                           "N": "str",
@@ -27324,7 +27324,7 @@
                                 {
                                   "N": "applyT",
                                   "sType": "* ",
-                                  "line": "1313",
+                                  "line": "1317",
                                   "mode": "Q{}operations.message.part",
                                   "bSlot": "2",
                                   "C": [
@@ -27335,7 +27335,7 @@
                                       "sType": "*NE",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1313"
+                                      "line": "1317"
                                     },
                                     {
                                       "N": "withParam",
@@ -27350,7 +27350,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1314"
+                                          "line": "1318"
                                         }
                                       ]
                                     }
@@ -27376,7 +27376,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1291",
+              "line": "1295",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:sequence",
@@ -27402,7 +27402,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1292",
+                      "line": "1296",
                       "C": [
                         {
                           "N": "str",
@@ -27424,7 +27424,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}ul ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "1293",
+                      "line": "1297",
                       "C": [
                         {
                           "N": "sequence",
@@ -27442,7 +27442,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "1294",
+                              "line": "1298",
                               "mode": "Q{}operations.message.part",
                               "bSlot": "2",
                               "C": [
@@ -27453,7 +27453,7 @@
                                   "sType": "*NE",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1294"
+                                  "line": "1298"
                                 },
                                 {
                                   "N": "withParam",
@@ -27468,7 +27468,7 @@
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1295"
+                                      "line": "1299"
                                     }
                                   ]
                                 }
@@ -27492,7 +27492,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1259",
+              "line": "1263",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:union",
@@ -27512,7 +27512,7 @@
                   "sType": "* ",
                   "name": "Q{}process-union",
                   "role": "action",
-                  "line": "1260",
+                  "line": "1264",
                   "C": [
                     {
                       "N": "withParam",
@@ -27527,7 +27527,7 @@
                           "sType": "*NA nQ{}memberTypes",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1261"
+                          "line": "1265"
                         }
                       ]
                     }
@@ -27545,7 +27545,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1232",
+              "line": "1236",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:restriction | xsd:extension",
@@ -27570,7 +27570,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1233",
+                      "line": "1237",
                       "C": [
                         {
                           "N": "str",
@@ -27591,7 +27591,7 @@
                       "var": "Q{}type-local-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1234",
+                      "line": "1238",
                       "C": [
                         {
                           "N": "fn",
@@ -27599,7 +27599,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1234",
+                          "line": "1238",
                           "C": [
                             {
                               "N": "fn",
@@ -27629,7 +27629,7 @@
                           "var": "Q{}type-name",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1235",
+                          "line": "1239",
                           "C": [
                             {
                               "N": "doc",
@@ -27641,7 +27641,7 @@
                                   "N": "choose",
                                   "sType": "?NT ",
                                   "type": "item()*",
-                                  "line": "1236",
+                                  "line": "1240",
                                   "C": [
                                     {
                                       "N": "varRef",
@@ -27649,13 +27649,13 @@
                                       "slot": "1",
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1237"
+                                      "line": "1241"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1238",
+                                      "line": "1242",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -27683,7 +27683,7 @@
                                                               "slot": "1",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1238"
+                                                              "line": "1242"
                                                             }
                                                           ]
                                                         }
@@ -27714,13 +27714,13 @@
                                       "nodeTest": "*NA nQ{}base",
                                       "sType": "*NA nQ{}base",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1240"
+                                      "line": "1244"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1241",
+                                      "line": "1245",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -27748,7 +27748,7 @@
                                                               "nodeTest": "*NA nQ{}base",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1241"
+                                                              "line": "1245"
                                                             }
                                                           ]
                                                         }
@@ -27794,14 +27794,14 @@
                               "var": "Q{}base-type",
                               "slot": "3",
                               "sType": "* ",
-                              "line": "1246",
+                              "line": "1250",
                               "C": [
                                 {
                                   "N": "first",
                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1246",
+                                  "line": "1250",
                                   "C": [
                                     {
                                       "N": "filter",
@@ -27840,7 +27840,7 @@
                                     {
                                       "N": "choose",
                                       "sType": "* ",
-                                      "line": "1250",
+                                      "line": "1254",
                                       "C": [
                                         {
                                           "N": "gc10",
@@ -27849,7 +27849,7 @@
                                           "card": "1:1",
                                           "sType": "1AB",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "1250",
+                                          "line": "1254",
                                           "C": [
                                             {
                                               "N": "varRef",
@@ -27862,7 +27862,7 @@
                                         {
                                           "N": "applyT",
                                           "sType": "* ",
-                                          "line": "1251",
+                                          "line": "1255",
                                           "mode": "Q{}operations.message.part",
                                           "bSlot": "2",
                                           "C": [
@@ -27873,7 +27873,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1251"
+                                              "line": "1255"
                                             },
                                             {
                                               "N": "withParam",
@@ -27888,7 +27888,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1252"
+                                                  "line": "1256"
                                                 }
                                               ]
                                             }
@@ -27901,7 +27901,7 @@
                                     {
                                       "N": "applyT",
                                       "sType": "* ",
-                                      "line": "1255",
+                                      "line": "1259",
                                       "mode": "Q{}operations.message.part",
                                       "bSlot": "2",
                                       "C": [
@@ -27912,7 +27912,7 @@
                                           "sType": "*NE",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1255"
+                                          "line": "1259"
                                         },
                                         {
                                           "N": "withParam",
@@ -27927,7 +27927,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1256"
+                                              "line": "1260"
                                             }
                                           ]
                                         }
@@ -27955,7 +27955,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1232",
+              "line": "1236",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:restriction | xsd:extension",
@@ -27980,7 +27980,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1233",
+                      "line": "1237",
                       "C": [
                         {
                           "N": "str",
@@ -28001,7 +28001,7 @@
                       "var": "Q{}type-local-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1234",
+                      "line": "1238",
                       "C": [
                         {
                           "N": "fn",
@@ -28009,7 +28009,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1234",
+                          "line": "1238",
                           "C": [
                             {
                               "N": "fn",
@@ -28039,7 +28039,7 @@
                           "var": "Q{}type-name",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1235",
+                          "line": "1239",
                           "C": [
                             {
                               "N": "doc",
@@ -28051,7 +28051,7 @@
                                   "N": "choose",
                                   "sType": "?NT ",
                                   "type": "item()*",
-                                  "line": "1236",
+                                  "line": "1240",
                                   "C": [
                                     {
                                       "N": "varRef",
@@ -28059,13 +28059,13 @@
                                       "slot": "1",
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1237"
+                                      "line": "1241"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1238",
+                                      "line": "1242",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -28093,7 +28093,7 @@
                                                               "slot": "1",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1238"
+                                                              "line": "1242"
                                                             }
                                                           ]
                                                         }
@@ -28124,13 +28124,13 @@
                                       "nodeTest": "*NA nQ{}base",
                                       "sType": "*NA nQ{}base",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1240"
+                                      "line": "1244"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1241",
+                                      "line": "1245",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -28158,7 +28158,7 @@
                                                               "nodeTest": "*NA nQ{}base",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1241"
+                                                              "line": "1245"
                                                             }
                                                           ]
                                                         }
@@ -28204,14 +28204,14 @@
                               "var": "Q{}base-type",
                               "slot": "3",
                               "sType": "* ",
-                              "line": "1246",
+                              "line": "1250",
                               "C": [
                                 {
                                   "N": "first",
                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1246",
+                                  "line": "1250",
                                   "C": [
                                     {
                                       "N": "filter",
@@ -28250,7 +28250,7 @@
                                     {
                                       "N": "choose",
                                       "sType": "* ",
-                                      "line": "1250",
+                                      "line": "1254",
                                       "C": [
                                         {
                                           "N": "gc10",
@@ -28259,7 +28259,7 @@
                                           "card": "1:1",
                                           "sType": "1AB",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "1250",
+                                          "line": "1254",
                                           "C": [
                                             {
                                               "N": "varRef",
@@ -28272,7 +28272,7 @@
                                         {
                                           "N": "applyT",
                                           "sType": "* ",
-                                          "line": "1251",
+                                          "line": "1255",
                                           "mode": "Q{}operations.message.part",
                                           "bSlot": "2",
                                           "C": [
@@ -28283,7 +28283,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1251"
+                                              "line": "1255"
                                             },
                                             {
                                               "N": "withParam",
@@ -28298,7 +28298,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1252"
+                                                  "line": "1256"
                                                 }
                                               ]
                                             }
@@ -28311,7 +28311,7 @@
                                     {
                                       "N": "applyT",
                                       "sType": "* ",
-                                      "line": "1255",
+                                      "line": "1259",
                                       "mode": "Q{}operations.message.part",
                                       "bSlot": "2",
                                       "C": [
@@ -28322,7 +28322,7 @@
                                           "sType": "*NE",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1255"
+                                          "line": "1259"
                                         },
                                         {
                                           "N": "withParam",
@@ -28337,7 +28337,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1256"
+                                              "line": "1260"
                                             }
                                           ]
                                         }
@@ -28365,7 +28365,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1199",
+              "line": "1203",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:complexContent",
@@ -28391,7 +28391,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1200",
+                      "line": "1204",
                       "C": [
                         {
                           "N": "str",
@@ -28410,7 +28410,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1202",
+                      "line": "1206",
                       "mode": "Q{}operations.message.part",
                       "bSlot": "2",
                       "C": [
@@ -28421,7 +28421,7 @@
                           "sType": "*NE",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1202"
+                          "line": "1206"
                         },
                         {
                           "N": "withParam",
@@ -28436,7 +28436,7 @@
                               "sType": "*",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1203"
+                              "line": "1207"
                             }
                           ]
                         }
@@ -28456,7 +28456,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1174",
+              "line": "1178",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:complexType",
@@ -28482,7 +28482,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1175",
+                      "line": "1179",
                       "C": [
                         {
                           "N": "str",
@@ -28503,7 +28503,7 @@
                       "var": "Q{}recursion.label",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1177",
+                      "line": "1181",
                       "C": [
                         {
                           "N": "fn",
@@ -28511,7 +28511,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1177",
+                          "line": "1181",
                           "C": [
                             { "N": "str", "val": "[" },
                             {
@@ -28539,7 +28539,7 @@
                           "var": "Q{}recursion.test",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1178",
+                          "line": "1182",
                           "C": [
                             {
                               "N": "doc",
@@ -28552,7 +28552,7 @@
                                   "bSlot": "1",
                                   "sType": "* ",
                                   "name": "Q{}recursion.should.continue",
-                                  "line": "1179",
+                                  "line": "1183",
                                   "C": [
                                     {
                                       "N": "withParam",
@@ -28567,7 +28567,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1180"
+                                          "line": "1184"
                                         }
                                       ]
                                     },
@@ -28584,7 +28584,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1181"
+                                          "line": "1185"
                                         }
                                       ]
                                     }
@@ -28596,7 +28596,7 @@
                               "N": "choose",
                               "sType": "* ",
                               "type": "item()*",
-                              "line": "1185",
+                              "line": "1189",
                               "C": [
                                 {
                                   "N": "gc10",
@@ -28605,7 +28605,7 @@
                                   "card": "1:1",
                                   "sType": "1AB",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1186",
+                                  "line": "1190",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -28635,7 +28635,7 @@
                                 {
                                   "N": "applyT",
                                   "sType": "* ",
-                                  "line": "1187",
+                                  "line": "1191",
                                   "mode": "Q{}operations.message.part",
                                   "bSlot": "2",
                                   "C": [
@@ -28646,7 +28646,7 @@
                                       "sType": "*NE",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1187"
+                                      "line": "1191"
                                     },
                                     {
                                       "N": "withParam",
@@ -28660,7 +28660,7 @@
                                           "sType": "1AS",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1188",
+                                          "line": "1192",
                                           "C": [
                                             {
                                               "N": "atomSing",
@@ -28709,7 +28709,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "1192",
+                                  "line": "1196",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -28732,7 +28732,7 @@
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1193",
+                                          "line": "1197",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -28759,7 +28759,7 @@
                                                                   "name": "Q{}RECURSIVE",
                                                                   "bSlot": "3",
                                                                   "role": "select",
-                                                                  "line": "1193"
+                                                                  "line": "1197"
                                                                 }
                                                               ]
                                                             }
@@ -28808,7 +28808,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1150",
+              "line": "1154",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:simpleType",
@@ -28852,7 +28852,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1636",
+              "line": "1640",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:enumeration[not(preceding-sibling::xsd:enumeration)]",
@@ -28903,7 +28903,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1638",
+                      "line": "1642",
                       "mode": "Q{}render-type.enum",
                       "bSlot": "0",
                       "C": [
@@ -28911,7 +28911,7 @@
                           "N": "docOrder",
                           "sType": "*NE",
                           "role": "select",
-                          "line": "1638",
+                          "line": "1642",
                           "C": [
                             {
                               "N": "union",
@@ -28954,7 +28954,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1618",
+              "line": "1622",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:attribute[ @*[local-name() = 'arrayType'] ]",
@@ -29004,7 +29004,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1619",
+                      "line": "1623",
                       "C": [
                         {
                           "N": "str",
@@ -29025,7 +29025,7 @@
                       "var": "Q{}array-local-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1621",
+                      "line": "1625",
                       "C": [
                         {
                           "N": "fn",
@@ -29033,7 +29033,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1621",
+                          "line": "1625",
                           "C": [
                             {
                               "N": "fn",
@@ -29082,7 +29082,7 @@
                           "var": "Q{}type-local-name",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1622",
+                          "line": "1626",
                           "C": [
                             {
                               "N": "fn",
@@ -29090,7 +29090,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1622",
+                              "line": "1626",
                               "C": [
                                 {
                                   "N": "fn",
@@ -29120,14 +29120,14 @@
                               "var": "Q{}array-type",
                               "slot": "3",
                               "sType": "* ",
-                              "line": "1623",
+                              "line": "1627",
                               "C": [
                                 {
                                   "N": "first",
                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1623",
+                                  "line": "1627",
                                   "C": [
                                     {
                                       "N": "filter",
@@ -29179,7 +29179,7 @@
                                       "bSlot": "2",
                                       "sType": "* ",
                                       "name": "Q{}render-type.write-name",
-                                      "line": "1626",
+                                      "line": "1630",
                                       "C": [
                                         {
                                           "N": "withParam",
@@ -29194,7 +29194,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1627"
+                                              "line": "1631"
                                             }
                                           ]
                                         }
@@ -29203,7 +29203,7 @@
                                     {
                                       "N": "applyT",
                                       "sType": "* ",
-                                      "line": "1630",
+                                      "line": "1634",
                                       "mode": "Q{}render-type",
                                       "bSlot": "3",
                                       "C": [
@@ -29214,7 +29214,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1630"
+                                          "line": "1634"
                                         },
                                         {
                                           "N": "withParam",
@@ -29229,7 +29229,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1631"
+                                              "line": "1635"
                                             }
                                           ]
                                         }
@@ -29257,7 +29257,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1581",
+              "line": "1585",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:simpleType/xsd:restriction/xsd:*[not(self::xsd:enumeration)]",
@@ -29321,7 +29321,7 @@
                       "N": "valueOf",
                       "flags": "l",
                       "sType": "1NT ",
-                      "line": "1583",
+                      "line": "1587",
                       "C": [
                         {
                           "N": "fn",
@@ -29337,7 +29337,7 @@
                                   "sType": "1AS",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1583",
+                                  "line": "1587",
                                   "C": [{ "N": "dot" }]
                                 }
                               ]
@@ -29356,7 +29356,7 @@
                       "N": "valueOf",
                       "flags": "l",
                       "sType": "1NT ",
-                      "line": "1585",
+                      "line": "1589",
                       "C": [
                         {
                           "N": "fn",
@@ -29384,7 +29384,7 @@
                                               "nodeTest": "*NA nQ{}value",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1585"
+                                              "line": "1589"
                                             }
                                           ]
                                         }
@@ -29424,7 +29424,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1555",
+              "line": "1559",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:restriction[ parent::xsd:simpleType ]",
@@ -29460,7 +29460,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1556",
+                      "line": "1560",
                       "C": [
                         {
                           "N": "str",
@@ -29481,7 +29481,7 @@
                       "var": "Q{}type-local-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1557",
+                      "line": "1561",
                       "C": [
                         {
                           "N": "fn",
@@ -29489,7 +29489,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1557",
+                          "line": "1561",
                           "C": [
                             {
                               "N": "fn",
@@ -29530,7 +29530,7 @@
                               "bSlot": "2",
                               "sType": "* ",
                               "name": "Q{}render-type.write-name",
-                              "line": "1571",
+                              "line": "1575",
                               "C": [
                                 {
                                   "N": "withParam",
@@ -29545,7 +29545,7 @@
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1572"
+                                      "line": "1576"
                                     }
                                   ]
                                 }
@@ -29562,7 +29562,7 @@
                               "N": "valueOf",
                               "flags": "l",
                               "sType": "1NT ",
-                              "line": "1575",
+                              "line": "1579",
                               "C": [
                                 {
                                   "N": "fn",
@@ -29578,7 +29578,7 @@
                                           "sType": "1AS",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1575",
+                                          "line": "1579",
                                           "C": [{ "N": "dot" }]
                                         }
                                       ]
@@ -29591,7 +29591,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "1576",
+                              "line": "1580",
                               "mode": "Q{}render-type",
                               "bSlot": "3",
                               "C": [
@@ -29602,7 +29602,7 @@
                                   "sType": "*NE",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1576"
+                                  "line": "1580"
                                 },
                                 {
                                   "N": "withParam",
@@ -29617,7 +29617,7 @@
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1577"
+                                      "line": "1581"
                                     }
                                   ]
                                 }
@@ -29641,7 +29641,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1634",
+              "line": "1638",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:enumeration",
@@ -29668,7 +29668,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1588",
+              "line": "1592",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:restriction | xsd:extension",
@@ -29693,7 +29693,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1589",
+                      "line": "1593",
                       "C": [
                         {
                           "N": "str",
@@ -29714,7 +29714,7 @@
                       "var": "Q{}type-local-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1590",
+                      "line": "1594",
                       "C": [
                         {
                           "N": "fn",
@@ -29722,7 +29722,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1590",
+                          "line": "1594",
                           "C": [
                             {
                               "N": "fn",
@@ -29752,7 +29752,7 @@
                           "var": "Q{}type-name",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1591",
+                          "line": "1595",
                           "C": [
                             {
                               "N": "doc",
@@ -29764,7 +29764,7 @@
                                   "N": "choose",
                                   "sType": "?NT ",
                                   "type": "item()*",
-                                  "line": "1592",
+                                  "line": "1596",
                                   "C": [
                                     {
                                       "N": "varRef",
@@ -29772,13 +29772,13 @@
                                       "slot": "1",
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1593"
+                                      "line": "1597"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1594",
+                                      "line": "1598",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -29806,7 +29806,7 @@
                                                               "slot": "1",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1594"
+                                                              "line": "1598"
                                                             }
                                                           ]
                                                         }
@@ -29837,13 +29837,13 @@
                                       "nodeTest": "*NA nQ{}base",
                                       "sType": "*NA nQ{}base",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1596"
+                                      "line": "1600"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1597",
+                                      "line": "1601",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -29871,7 +29871,7 @@
                                                               "nodeTest": "*NA nQ{}base",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1597"
+                                                              "line": "1601"
                                                             }
                                                           ]
                                                         }
@@ -29917,14 +29917,14 @@
                               "var": "Q{}base-type",
                               "slot": "3",
                               "sType": "* ",
-                              "line": "1602",
+                              "line": "1606",
                               "C": [
                                 {
                                   "N": "first",
                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1602",
+                                  "line": "1606",
                                   "C": [
                                     {
                                       "N": "filter",
@@ -29961,7 +29961,7 @@
                                   "var": "Q{}abstract",
                                   "slot": "4",
                                   "sType": "* ",
-                                  "line": "1603",
+                                  "line": "1607",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -29972,12 +29972,12 @@
                                         {
                                           "N": "choose",
                                           "sType": "? ",
-                                          "line": "1604",
+                                          "line": "1608",
                                           "C": [
                                             {
                                               "N": "docOrder",
                                               "sType": "*NA nQ{}abstract",
-                                              "line": "1604",
+                                              "line": "1608",
                                               "C": [
                                                 {
                                                   "N": "docOrder",
@@ -30035,14 +30035,14 @@
                                         {
                                           "N": "choose",
                                           "sType": "* ",
-                                          "line": "1607",
+                                          "line": "1611",
                                           "C": [
                                             {
                                               "N": "fn",
                                               "name": "not",
                                               "sType": "1AB",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1607",
+                                              "line": "1611",
                                               "C": [
                                                 {
                                                   "N": "gc10",
@@ -30071,7 +30071,7 @@
                                                   "N": "valueOf",
                                                   "flags": "l",
                                                   "sType": "1NT ",
-                                                  "line": "1608",
+                                                  "line": "1612",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -30087,7 +30087,7 @@
                                                               "sType": "1AS",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1608",
+                                                              "line": "1612",
                                                               "C": [
                                                                 {
                                                                   "N": "str",
@@ -30141,7 +30141,7 @@
                                                   "bSlot": "2",
                                                   "sType": "* ",
                                                   "name": "Q{}render-type.write-name",
-                                                  "line": "1609",
+                                                  "line": "1613",
                                                   "C": [
                                                     {
                                                       "N": "withParam",
@@ -30156,7 +30156,7 @@
                                                           "sType": "*",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1610"
+                                                          "line": "1614"
                                                         }
                                                       ]
                                                     }
@@ -30171,7 +30171,7 @@
                                         {
                                           "N": "applyT",
                                           "sType": "* ",
-                                          "line": "1614",
+                                          "line": "1618",
                                           "mode": "Q{}render-type",
                                           "bSlot": "3",
                                           "C": [
@@ -30181,7 +30181,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1614",
+                                              "line": "1618",
                                               "C": [
                                                 {
                                                   "N": "docOrder",
@@ -30220,7 +30220,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1615"
+                                                  "line": "1619"
                                                 }
                                               ]
                                             }
@@ -30250,7 +30250,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1588",
+              "line": "1592",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:restriction | xsd:extension",
@@ -30275,7 +30275,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1589",
+                      "line": "1593",
                       "C": [
                         {
                           "N": "str",
@@ -30296,7 +30296,7 @@
                       "var": "Q{}type-local-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1590",
+                      "line": "1594",
                       "C": [
                         {
                           "N": "fn",
@@ -30304,7 +30304,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1590",
+                          "line": "1594",
                           "C": [
                             {
                               "N": "fn",
@@ -30334,7 +30334,7 @@
                           "var": "Q{}type-name",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1591",
+                          "line": "1595",
                           "C": [
                             {
                               "N": "doc",
@@ -30346,7 +30346,7 @@
                                   "N": "choose",
                                   "sType": "?NT ",
                                   "type": "item()*",
-                                  "line": "1592",
+                                  "line": "1596",
                                   "C": [
                                     {
                                       "N": "varRef",
@@ -30354,13 +30354,13 @@
                                       "slot": "1",
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1593"
+                                      "line": "1597"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1594",
+                                      "line": "1598",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -30388,7 +30388,7 @@
                                                               "slot": "1",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1594"
+                                                              "line": "1598"
                                                             }
                                                           ]
                                                         }
@@ -30419,13 +30419,13 @@
                                       "nodeTest": "*NA nQ{}base",
                                       "sType": "*NA nQ{}base",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1596"
+                                      "line": "1600"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1597",
+                                      "line": "1601",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -30453,7 +30453,7 @@
                                                               "nodeTest": "*NA nQ{}base",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1597"
+                                                              "line": "1601"
                                                             }
                                                           ]
                                                         }
@@ -30499,14 +30499,14 @@
                               "var": "Q{}base-type",
                               "slot": "3",
                               "sType": "* ",
-                              "line": "1602",
+                              "line": "1606",
                               "C": [
                                 {
                                   "N": "first",
                                   "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1602",
+                                  "line": "1606",
                                   "C": [
                                     {
                                       "N": "filter",
@@ -30543,7 +30543,7 @@
                                   "var": "Q{}abstract",
                                   "slot": "4",
                                   "sType": "* ",
-                                  "line": "1603",
+                                  "line": "1607",
                                   "C": [
                                     {
                                       "N": "doc",
@@ -30554,12 +30554,12 @@
                                         {
                                           "N": "choose",
                                           "sType": "? ",
-                                          "line": "1604",
+                                          "line": "1608",
                                           "C": [
                                             {
                                               "N": "docOrder",
                                               "sType": "*NA nQ{}abstract",
-                                              "line": "1604",
+                                              "line": "1608",
                                               "C": [
                                                 {
                                                   "N": "docOrder",
@@ -30617,14 +30617,14 @@
                                         {
                                           "N": "choose",
                                           "sType": "* ",
-                                          "line": "1607",
+                                          "line": "1611",
                                           "C": [
                                             {
                                               "N": "fn",
                                               "name": "not",
                                               "sType": "1AB",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1607",
+                                              "line": "1611",
                                               "C": [
                                                 {
                                                   "N": "gc10",
@@ -30653,7 +30653,7 @@
                                                   "N": "valueOf",
                                                   "flags": "l",
                                                   "sType": "1NT ",
-                                                  "line": "1608",
+                                                  "line": "1612",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -30669,7 +30669,7 @@
                                                               "sType": "1AS",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1608",
+                                                              "line": "1612",
                                                               "C": [
                                                                 {
                                                                   "N": "str",
@@ -30723,7 +30723,7 @@
                                                   "bSlot": "2",
                                                   "sType": "* ",
                                                   "name": "Q{}render-type.write-name",
-                                                  "line": "1609",
+                                                  "line": "1613",
                                                   "C": [
                                                     {
                                                       "N": "withParam",
@@ -30738,7 +30738,7 @@
                                                           "sType": "*",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1610"
+                                                          "line": "1614"
                                                         }
                                                       ]
                                                     }
@@ -30753,7 +30753,7 @@
                                         {
                                           "N": "applyT",
                                           "sType": "* ",
-                                          "line": "1614",
+                                          "line": "1618",
                                           "mode": "Q{}render-type",
                                           "bSlot": "3",
                                           "C": [
@@ -30763,7 +30763,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1614",
+                                              "line": "1618",
                                               "C": [
                                                 {
                                                   "N": "docOrder",
@@ -30802,7 +30802,7 @@
                                                   "sType": "*",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1615"
+                                                  "line": "1619"
                                                 }
                                               ]
                                             }
@@ -30832,7 +30832,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1549",
+              "line": "1553",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:element | xsd:complexType | xsd:simpleType | xsd:complexContent",
@@ -30857,7 +30857,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1550",
+                      "line": "1554",
                       "C": [
                         {
                           "N": "str",
@@ -30876,7 +30876,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1551",
+                      "line": "1555",
                       "mode": "Q{}render-type",
                       "bSlot": "3",
                       "C": [
@@ -30887,7 +30887,7 @@
                           "sType": "*NE",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1551"
+                          "line": "1555"
                         },
                         {
                           "N": "withParam",
@@ -30902,7 +30902,7 @@
                               "sType": "*",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1552"
+                              "line": "1556"
                             }
                           ]
                         }
@@ -30922,7 +30922,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1549",
+              "line": "1553",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:element | xsd:complexType | xsd:simpleType | xsd:complexContent",
@@ -30947,7 +30947,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1550",
+                      "line": "1554",
                       "C": [
                         {
                           "N": "str",
@@ -30966,7 +30966,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1551",
+                      "line": "1555",
                       "mode": "Q{}render-type",
                       "bSlot": "3",
                       "C": [
@@ -30977,7 +30977,7 @@
                           "sType": "*NE",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1551"
+                          "line": "1555"
                         },
                         {
                           "N": "withParam",
@@ -30992,7 +30992,7 @@
                               "sType": "*",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1552"
+                              "line": "1556"
                             }
                           ]
                         }
@@ -31012,7 +31012,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1549",
+              "line": "1553",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:element | xsd:complexType | xsd:simpleType | xsd:complexContent",
@@ -31037,7 +31037,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1550",
+                      "line": "1554",
                       "C": [
                         {
                           "N": "str",
@@ -31056,7 +31056,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1551",
+                      "line": "1555",
                       "mode": "Q{}render-type",
                       "bSlot": "3",
                       "C": [
@@ -31067,7 +31067,7 @@
                           "sType": "*NE",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1551"
+                          "line": "1555"
                         },
                         {
                           "N": "withParam",
@@ -31082,7 +31082,7 @@
                               "sType": "*",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1552"
+                              "line": "1556"
                             }
                           ]
                         }
@@ -31102,7 +31102,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1549",
+              "line": "1553",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:element | xsd:complexType | xsd:simpleType | xsd:complexContent",
@@ -31127,7 +31127,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1550",
+                      "line": "1554",
                       "C": [
                         {
                           "N": "str",
@@ -31146,7 +31146,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1551",
+                      "line": "1555",
                       "mode": "Q{}render-type",
                       "bSlot": "3",
                       "C": [
@@ -31157,7 +31157,7 @@
                           "sType": "*NE",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1551"
+                          "line": "1555"
                         },
                         {
                           "N": "withParam",
@@ -31172,7 +31172,7 @@
                               "sType": "*",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1552"
+                              "line": "1556"
                             }
                           ]
                         }
@@ -31192,7 +31192,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1547",
+              "line": "1551",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*",
@@ -31236,7 +31236,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1641",
+              "line": "1645",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:enumeration",
@@ -31258,14 +31258,14 @@
                     {
                       "N": "choose",
                       "sType": "? ",
-                      "line": "1642",
+                      "line": "1646",
                       "C": [
                         {
                           "N": "fn",
                           "name": "reverse",
                           "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}enumeration",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                          "line": "1642",
+                          "line": "1646",
                           "C": [
                             {
                               "N": "axis",
@@ -31293,7 +31293,7 @@
                       "N": "valueOf",
                       "flags": "l",
                       "sType": "1NT ",
-                      "line": "1646",
+                      "line": "1650",
                       "C": [
                         {
                           "N": "fn",
@@ -31321,7 +31321,7 @@
                                               "nodeTest": "*NA nQ{}value",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1646"
+                                              "line": "1650"
                                             }
                                           ]
                                         }
@@ -31379,7 +31379,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1663",
+              "line": "1667",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "@*",
@@ -31405,7 +31405,7 @@
                       "sType": "* ",
                       "as": "* ",
                       "flags": "",
-                      "line": "1664",
+                      "line": "1668",
                       "C": [
                         {
                           "N": "str",
@@ -31426,7 +31426,7 @@
                       "var": "Q{}recursion.label",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1665",
+                      "line": "1669",
                       "C": [
                         {
                           "N": "fn",
@@ -31434,7 +31434,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1665",
+                          "line": "1669",
                           "C": [
                             { "N": "str", "val": "[" },
                             {
@@ -31450,7 +31450,7 @@
                           "var": "Q{}recursion.check",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1666",
+                          "line": "1670",
                           "C": [
                             {
                               "N": "fn",
@@ -31458,7 +31458,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1666",
+                              "line": "1670",
                               "C": [
                                 {
                                   "N": "atomSing",
@@ -31500,14 +31500,14 @@
                               "N": "choose",
                               "sType": "* ",
                               "type": "item()*",
-                              "line": "1668",
+                              "line": "1672",
                               "C": [
                                 {
                                   "N": "fn",
                                   "name": "contains",
                                   "sType": "1AB",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1669",
+                                  "line": "1673",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -31553,7 +31553,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}h2 ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "1670",
+                                  "line": "1674",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -31576,7 +31576,7 @@
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1671",
+                                          "line": "1675",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -31592,7 +31592,7 @@
                                                       "sType": "1AS",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1671",
+                                                      "line": "1675",
                                                       "C": [
                                                         {
                                                           "N": "str",
@@ -31643,7 +31643,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}h2 ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "1675",
+                                      "line": "1679",
                                       "C": [
                                         {
                                           "N": "elem",
@@ -31651,7 +31651,7 @@
                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                          "line": "1676",
+                                          "line": "1680",
                                           "C": [
                                             {
                                               "N": "sequence",
@@ -31689,7 +31689,7 @@
                                                                           "name": "concat",
                                                                           "sType": "1AS",
                                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                                          "line": "1676",
+                                                                          "line": "1680",
                                                                           "C": [
                                                                             {
                                                                               "N": "atomSing",
@@ -31737,7 +31737,7 @@
                                                   "N": "choose",
                                                   "sType": "?NT ",
                                                   "type": "item()*",
-                                                  "line": "1677",
+                                                  "line": "1681",
                                                   "C": [
                                                     {
                                                       "N": "axis",
@@ -31745,7 +31745,7 @@
                                                       "nodeTest": "*NE nQ{http://www.w3.org/2001/XMLSchema}include",
                                                       "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}include",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                      "line": "1678"
+                                                      "line": "1682"
                                                     },
                                                     {
                                                       "N": "valueOf",
@@ -31776,7 +31776,7 @@
                                                   "N": "choose",
                                                   "sType": "?NT ",
                                                   "type": "item()*",
-                                                  "line": "1682",
+                                                  "line": "1686",
                                                   "C": [
                                                     {
                                                       "N": "gc10",
@@ -31785,7 +31785,7 @@
                                                       "card": "1:1",
                                                       "sType": "1AB",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                      "line": "1683",
+                                                      "line": "1687",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -31829,13 +31829,13 @@
                                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}i ",
                                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                                  "line": "1686",
+                                                  "line": "1690",
                                                   "C": [
                                                     {
                                                       "N": "valueOf",
                                                       "flags": "l",
                                                       "sType": "1NT ",
-                                                      "line": "1687",
+                                                      "line": "1691",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -31861,7 +31861,7 @@
                                                                               "sType": "1NA",
                                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                                               "role": "select",
-                                                                              "line": "1687"
+                                                                              "line": "1691"
                                                                             }
                                                                           ]
                                                                         }
@@ -31904,7 +31904,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "1692",
+                                      "line": "1696",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -31954,7 +31954,7 @@
                                                                       "N": "dot",
                                                                       "sType": "1NA",
                                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                                      "line": "1692"
+                                                                      "line": "1696"
                                                                     }
                                                                   ]
                                                                 }
@@ -31976,7 +31976,7 @@
                                             {
                                               "N": "applyT",
                                               "sType": "* ",
-                                              "line": "1693",
+                                              "line": "1697",
                                               "mode": "Q{}src",
                                               "bSlot": "1",
                                               "C": [
@@ -31984,7 +31984,7 @@
                                                   "N": "docOrder",
                                                   "sType": "*N",
                                                   "role": "select",
-                                                  "line": "1693",
+                                                  "line": "1697",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -32010,7 +32010,7 @@
                                     {
                                       "N": "applyT",
                                       "sType": "* ",
-                                      "line": "1697",
+                                      "line": "1701",
                                       "mode": "Q{}src.import",
                                       "bSlot": "2",
                                       "C": [
@@ -32018,7 +32018,7 @@
                                           "N": "docOrder",
                                           "sType": "*NA nQ{}location",
                                           "role": "select",
-                                          "line": "1697",
+                                          "line": "1701",
                                           "C": [
                                             {
                                               "N": "docOrder",
@@ -32126,7 +32126,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1698"
+                                              "line": "1702"
                                             }
                                           ]
                                         }
@@ -32135,7 +32135,7 @@
                                     {
                                       "N": "applyT",
                                       "sType": "* ",
-                                      "line": "1701",
+                                      "line": "1705",
                                       "mode": "Q{}src.import",
                                       "bSlot": "2",
                                       "C": [
@@ -32143,7 +32143,7 @@
                                           "N": "docOrder",
                                           "sType": "*NA nQ{}schemaLocation",
                                           "role": "select",
-                                          "line": "1701",
+                                          "line": "1705",
                                           "C": [
                                             {
                                               "N": "docOrder",
@@ -32225,7 +32225,7 @@
                                               "sType": "*",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                               "role": "select",
-                                              "line": "1702"
+                                              "line": "1706"
                                             }
                                           ]
                                         }
@@ -32270,7 +32270,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1986",
+              "line": "1990",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "processing-instruction()",
@@ -32291,7 +32291,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "1987",
+                  "line": "1991",
                   "C": [
                     {
                       "N": "sequence",
@@ -32315,7 +32315,7 @@
                           "N": "copyOf",
                           "flags": "c",
                           "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ex=http://ns.saxonica.com/xslt/export",
-                          "line": "1989",
+                          "line": "1993",
                           "sType": "1AS",
                           "C": [
                             {
@@ -32324,7 +32324,7 @@
                               "sType": "1AS",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1989",
+                              "line": "1993",
                               "C": [{ "N": "dot" }]
                             }
                           ]
@@ -32333,7 +32333,7 @@
                           "N": "valueOf",
                           "flags": "d",
                           "sType": "1NT ",
-                          "line": "1990",
+                          "line": "1994",
                           "C": [
                             {
                               "N": "fn",
@@ -32349,7 +32349,7 @@
                                       "sType": "1AS",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1990",
+                                      "line": "1994",
                                       "C": [
                                         { "N": "str", "val": " " },
                                         {
@@ -32388,7 +32388,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1978",
+              "line": "1982",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "comment()",
@@ -32409,7 +32409,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "1979",
+                  "line": "1983",
                   "C": [
                     {
                       "N": "sequence",
@@ -32437,7 +32437,7 @@
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "1981",
+                          "line": "1985",
                           "C": [
                             {
                               "N": "fn",
@@ -32463,7 +32463,7 @@
                                                   "sType": "1NC",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1981"
+                                                  "line": "1985"
                                                 }
                                               ]
                                             }
@@ -32507,7 +32507,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1973",
+              "line": "1977",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "text()",
@@ -32528,7 +32528,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "1974",
+                  "line": "1978",
                   "C": [
                     {
                       "N": "sequence",
@@ -32547,7 +32547,7 @@
                           "N": "valueOf",
                           "flags": "l",
                           "sType": "1NT ",
-                          "line": "1975",
+                          "line": "1979",
                           "C": [
                             {
                               "N": "fn",
@@ -32573,7 +32573,7 @@
                                                   "sType": "1NT",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1975"
+                                                  "line": "1979"
                                                 }
                                               ]
                                             }
@@ -32610,7 +32610,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1912",
+              "line": "1916",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "@*",
@@ -32640,7 +32640,7 @@
                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                       "nsuri": "http://www.w3.org/1999/xhtml",
                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                      "line": "1914",
+                      "line": "1918",
                       "C": [
                         {
                           "N": "sequence",
@@ -32663,7 +32663,7 @@
                               "N": "valueOf",
                               "flags": "l",
                               "sType": "1NT ",
-                              "line": "1915",
+                              "line": "1919",
                               "C": [
                                 {
                                   "N": "fn",
@@ -32679,7 +32679,7 @@
                                           "sType": "1AS",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1915",
+                                          "line": "1919",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -32702,7 +32702,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "1916",
+                              "line": "1920",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -32725,7 +32725,7 @@
                                       "N": "valueOf",
                                       "flags": "d",
                                       "sType": "1NT ",
-                                      "line": "1917",
+                                      "line": "1921",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -32741,7 +32741,7 @@
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1917",
+                                                  "line": "1921",
                                                   "C": [
                                                     { "N": "str", "val": "\"" },
                                                     {
@@ -32786,7 +32786,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1707",
+              "line": "1711",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*",
@@ -32807,7 +32807,7 @@
                   "nsuri": "http://www.w3.org/1999/xhtml",
                   "namespaces": "=http://www.w3.org/1999/xhtml",
                   "role": "action",
-                  "line": "1708",
+                  "line": "1712",
                   "C": [
                     {
                       "N": "sequence",
@@ -32832,7 +32832,7 @@
                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}a ",
                           "nsuri": "http://www.w3.org/1999/xhtml",
                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                          "line": "1709",
+                          "line": "1713",
                           "C": [
                             {
                               "N": "sequence",
@@ -32870,7 +32870,7 @@
                                                           "name": "concat",
                                                           "sType": "1AS",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                                          "line": "1709",
+                                                          "line": "1713",
                                                           "C": [
                                                             {
                                                               "N": "atomSing",
@@ -32913,7 +32913,7 @@
                                 {
                                   "N": "applyT",
                                   "sType": "* ",
-                                  "line": "1710",
+                                  "line": "1714",
                                   "mode": "Q{}src.link",
                                   "bSlot": "1",
                                   "C": [
@@ -32922,14 +32922,14 @@
                                       "sType": "1NE",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1710"
+                                      "line": "1714"
                                     }
                                   ]
                                 },
                                 {
                                   "N": "applyT",
                                   "sType": "* ",
-                                  "line": "1711",
+                                  "line": "1715",
                                   "mode": "Q{}src.start-tag",
                                   "bSlot": "2",
                                   "C": [
@@ -32938,7 +32938,7 @@
                                       "sType": "1NE",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1711"
+                                      "line": "1715"
                                     }
                                   ]
                                 }
@@ -32949,7 +32949,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1714",
+                          "line": "1718",
                           "mode": "Q{}src",
                           "bSlot": "3",
                           "C": [
@@ -32957,7 +32957,7 @@
                               "N": "docOrder",
                               "sType": "*N u[N u[N u[NE,NC],NP],NT]",
                               "role": "select",
-                              "line": "1714",
+                              "line": "1718",
                               "C": [
                                 {
                                   "N": "union",
@@ -33037,7 +33037,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1715",
+                          "line": "1719",
                           "mode": "Q{}src.end-tag",
                           "bSlot": "4",
                           "C": [
@@ -33046,7 +33046,7 @@
                               "sType": "1NE",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1715"
+                              "line": "1719"
                             }
                           ]
                         }
@@ -33083,7 +33083,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1724",
+              "line": "1728",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*[*|comment()|processing-instruction()|text()[string-length(normalize-space(.)) > 0]]",
@@ -33172,7 +33172,7 @@
                   "sType": "* ",
                   "name": "Q{}src.elem",
                   "role": "action",
-                  "line": "1725"
+                  "line": "1729"
                 }
               ]
             },
@@ -33186,7 +33186,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1718",
+              "line": "1722",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*",
@@ -33206,7 +33206,7 @@
                   "sType": "* ",
                   "name": "Q{}src.elem",
                   "role": "action",
-                  "line": "1719",
+                  "line": "1723",
                   "C": [
                     {
                       "N": "withParam",
@@ -33268,7 +33268,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1729",
+              "line": "1733",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*[*|comment()|processing-instruction()|text()[string-length(normalize-space(.)) > 0]]",
@@ -33357,7 +33357,7 @@
                   "sType": "* ",
                   "name": "Q{}src.elem",
                   "role": "action",
-                  "line": "1730",
+                  "line": "1734",
                   "C": [
                     {
                       "N": "withParam",
@@ -33402,7 +33402,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1727",
+              "line": "1731",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*",
@@ -33446,7 +33446,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1734",
+              "line": "1738",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*",
@@ -33464,20 +33464,20 @@
                   "N": "choose",
                   "sType": "? ",
                   "role": "action",
-                  "line": "1735",
+                  "line": "1739",
                   "C": [
                     {
                       "N": "gVarRef",
                       "name": "Q{}ENABLE-LINK",
                       "bSlot": "0",
                       "sType": "* ",
-                      "line": "1735"
+                      "line": "1739"
                     },
                     {
                       "N": "att",
                       "name": "href",
                       "sType": "1NA ",
-                      "line": "1736",
+                      "line": "1740",
                       "C": [
                         {
                           "N": "fn",
@@ -33502,7 +33502,7 @@
                                               "N": "valueOf",
                                               "sType": "1NT ",
                                               "flags": "l",
-                                              "line": "1737",
+                                              "line": "1741",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -33518,7 +33518,7 @@
                                                           "sType": "1AS",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1737",
+                                                          "line": "1741",
                                                           "C": [
                                                             {
                                                               "N": "str",
@@ -33608,7 +33608,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1866",
+              "line": "1870",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:attribute[contains(@ref, 'arrayType')]",
@@ -33656,7 +33656,7 @@
                   "var": "Q{}att-array-type",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1868",
+                  "line": "1872",
                   "role": "action",
                   "C": [
                     {
@@ -33665,7 +33665,7 @@
                       "sType": "1AS",
                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                       "role": "select",
-                      "line": "1868",
+                      "line": "1872",
                       "C": [
                         {
                           "N": "fn",
@@ -33714,7 +33714,7 @@
                       "var": "Q{}xsd-local-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1869",
+                      "line": "1873",
                       "C": [
                         {
                           "N": "fn",
@@ -33722,7 +33722,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1869",
+                          "line": "1873",
                           "C": [
                             {
                               "N": "fn",
@@ -33752,7 +33752,7 @@
                           "var": "Q{}xsd-name",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1870",
+                          "line": "1874",
                           "C": [
                             {
                               "N": "doc",
@@ -33764,7 +33764,7 @@
                                   "N": "choose",
                                   "sType": "?NT ",
                                   "type": "item()*",
-                                  "line": "1871",
+                                  "line": "1875",
                                   "C": [
                                     {
                                       "N": "varRef",
@@ -33772,13 +33772,13 @@
                                       "slot": "1",
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1872"
+                                      "line": "1876"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1873",
+                                      "line": "1877",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -33806,7 +33806,7 @@
                                                               "slot": "1",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1873"
+                                                              "line": "1877"
                                                             }
                                                           ]
                                                         }
@@ -33836,7 +33836,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1876",
+                                      "line": "1880",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -33864,7 +33864,7 @@
                                                               "slot": "0",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1876"
+                                                              "line": "1880"
                                                             }
                                                           ]
                                                         }
@@ -33896,7 +33896,7 @@
                             {
                               "N": "choose",
                               "sType": "* ",
-                              "line": "1880",
+                              "line": "1884",
                               "C": [
                                 {
                                   "N": "varRef",
@@ -33904,21 +33904,21 @@
                                   "slot": "2",
                                   "sType": "*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1880"
+                                  "line": "1884"
                                 },
                                 {
                                   "N": "let",
                                   "var": "Q{}msg",
                                   "slot": "3",
                                   "sType": "* ",
-                                  "line": "1881",
+                                  "line": "1885",
                                   "C": [
                                     {
                                       "N": "first",
                                       "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1881",
+                                      "line": "1885",
                                       "C": [
                                         {
                                           "N": "filter",
@@ -33953,7 +33953,7 @@
                                     {
                                       "N": "applyT",
                                       "sType": "* ",
-                                      "line": "1882",
+                                      "line": "1886",
                                       "mode": "Q{}src.link-attribute",
                                       "bSlot": "1",
                                       "C": [
@@ -33964,7 +33964,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1882"
+                                          "line": "1886"
                                         }
                                       ]
                                     }
@@ -33992,7 +33992,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1835",
+              "line": "1839",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:element[@ref or @type]",
@@ -34031,7 +34031,7 @@
                   "var": "Q{}ref-or-type",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1836",
+                  "line": "1840",
                   "role": "action",
                   "C": [
                     {
@@ -34044,7 +34044,7 @@
                           "N": "choose",
                           "sType": "?NT ",
                           "type": "item()*",
-                          "line": "1837",
+                          "line": "1841",
                           "C": [
                             {
                               "N": "axis",
@@ -34052,13 +34052,13 @@
                               "nodeTest": "*NA nQ{}type",
                               "sType": "*NA nQ{}type",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                              "line": "1838"
+                              "line": "1842"
                             },
                             {
                               "N": "valueOf",
                               "flags": "l",
                               "sType": "1NT ",
-                              "line": "1839",
+                              "line": "1843",
                               "C": [
                                 {
                                   "N": "fn",
@@ -34086,7 +34086,7 @@
                                                       "nodeTest": "*NA nQ{}type",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1839"
+                                                      "line": "1843"
                                                     }
                                                   ]
                                                 }
@@ -34112,7 +34112,7 @@
                               "N": "valueOf",
                               "flags": "l",
                               "sType": "1NT ",
-                              "line": "1842",
+                              "line": "1846",
                               "C": [
                                 {
                                   "N": "fn",
@@ -34140,7 +34140,7 @@
                                                       "nodeTest": "*NA nQ{}ref",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1842"
+                                                      "line": "1846"
                                                     }
                                                   ]
                                                 }
@@ -34170,7 +34170,7 @@
                       "var": "Q{}type-local-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1847",
+                      "line": "1851",
                       "C": [
                         {
                           "N": "fn",
@@ -34178,7 +34178,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1847",
+                          "line": "1851",
                           "C": [
                             {
                               "N": "fn",
@@ -34208,7 +34208,7 @@
                           "var": "Q{}xsd-name",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1848",
+                          "line": "1852",
                           "C": [
                             {
                               "N": "doc",
@@ -34220,7 +34220,7 @@
                                   "N": "choose",
                                   "sType": "? ",
                                   "type": "item()*",
-                                  "line": "1849",
+                                  "line": "1853",
                                   "C": [
                                     {
                                       "N": "varRef",
@@ -34228,13 +34228,13 @@
                                       "slot": "1",
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1850"
+                                      "line": "1854"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1851",
+                                      "line": "1855",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -34262,7 +34262,7 @@
                                                               "slot": "1",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1851"
+                                                              "line": "1855"
                                                             }
                                                           ]
                                                         }
@@ -34293,13 +34293,13 @@
                                       "slot": "0",
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1853"
+                                      "line": "1857"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1854",
+                                      "line": "1858",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -34327,7 +34327,7 @@
                                                               "slot": "0",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1854"
+                                                              "line": "1858"
                                                             }
                                                           ]
                                                         }
@@ -34361,7 +34361,7 @@
                             {
                               "N": "choose",
                               "sType": "* ",
-                              "line": "1860",
+                              "line": "1864",
                               "C": [
                                 {
                                   "N": "varRef",
@@ -34369,21 +34369,21 @@
                                   "slot": "2",
                                   "sType": "*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1860"
+                                  "line": "1864"
                                 },
                                 {
                                   "N": "let",
                                   "var": "Q{}msg",
                                   "slot": "3",
                                   "sType": "* ",
-                                  "line": "1862",
+                                  "line": "1866",
                                   "C": [
                                     {
                                       "N": "first",
                                       "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                       "role": "select",
-                                      "line": "1862",
+                                      "line": "1866",
                                       "C": [
                                         {
                                           "N": "filter",
@@ -34442,7 +34442,7 @@
                                     {
                                       "N": "applyT",
                                       "sType": "* ",
-                                      "line": "1863",
+                                      "line": "1867",
                                       "mode": "Q{}src.link-attribute",
                                       "bSlot": "1",
                                       "C": [
@@ -34453,7 +34453,7 @@
                                           "sType": "*",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                           "role": "select",
-                                          "line": "1863"
+                                          "line": "1867"
                                         }
                                       ]
                                     }
@@ -34481,7 +34481,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1828",
+              "line": "1832",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation[@name and parent::ws:binding/@type]",
@@ -34536,7 +34536,7 @@
                   "var": "Q{}type-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1829",
+                  "line": "1833",
                   "role": "action",
                   "C": [
                     {
@@ -34548,7 +34548,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1830",
+                          "line": "1834",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -34556,7 +34556,7 @@
                               "N": "docOrder",
                               "sType": "*NA nQ{}type",
                               "role": "select",
-                              "line": "1830",
+                              "line": "1834",
                               "C": [
                                 {
                                   "N": "slash",
@@ -34585,7 +34585,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1833",
+                      "line": "1837",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -34595,7 +34595,7 @@
                           "slot": "199",
                           "xpath": "$consolidated-wsdl/ws:portType[@name = $type-name]/ws:operation[@name = current()/@name]",
                           "loc": "xsl:apply-templates/@select",
-                          "line": "1833",
+                          "line": "1837",
                           "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                           "role": "select",
                           "BC": "true",
@@ -34717,7 +34717,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1821",
+              "line": "1825",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:service/ws:port[@binding]",
@@ -34756,7 +34756,7 @@
                   "var": "Q{}binding-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1822",
+                  "line": "1826",
                   "role": "action",
                   "C": [
                     {
@@ -34768,7 +34768,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1823",
+                          "line": "1827",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -34779,7 +34779,7 @@
                               "sType": "*NA nQ{}binding",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1823"
+                              "line": "1827"
                             }
                           ]
                         }
@@ -34788,7 +34788,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1826",
+                      "line": "1830",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -34796,7 +34796,7 @@
                           "N": "docOrder",
                           "sType": "*NE nQ{http://schemas.xmlsoap.org/wsdl/}binding",
                           "role": "select",
-                          "line": "1826",
+                          "line": "1830",
                           "C": [
                             {
                               "N": "docOrder",
@@ -34862,7 +34862,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1796",
+              "line": "1800",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:message/ws:part[@element or @type]",
@@ -34911,7 +34911,7 @@
                   "var": "Q{}elem-local-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1797",
+                  "line": "1801",
                   "role": "action",
                   "C": [
                     {
@@ -34920,7 +34920,7 @@
                       "sType": "1AS",
                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                       "role": "select",
-                      "line": "1797",
+                      "line": "1801",
                       "C": [
                         {
                           "N": "fn",
@@ -34950,7 +34950,7 @@
                       "var": "Q{}type-local-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1798",
+                      "line": "1802",
                       "C": [
                         {
                           "N": "fn",
@@ -34958,7 +34958,7 @@
                           "sType": "1AS",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1798",
+                          "line": "1802",
                           "C": [
                             {
                               "N": "fn",
@@ -34988,7 +34988,7 @@
                           "var": "Q{}elem-name",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1799",
+                          "line": "1803",
                           "C": [
                             {
                               "N": "doc",
@@ -35000,7 +35000,7 @@
                                   "N": "choose",
                                   "sType": "* ",
                                   "type": "item()*",
-                                  "line": "1800",
+                                  "line": "1804",
                                   "C": [
                                     {
                                       "N": "varRef",
@@ -35008,13 +35008,13 @@
                                       "slot": "0",
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1801"
+                                      "line": "1805"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1802",
+                                      "line": "1806",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -35042,7 +35042,7 @@
                                                               "slot": "0",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1802"
+                                                              "line": "1806"
                                                             }
                                                           ]
                                                         }
@@ -35073,13 +35073,13 @@
                                       "slot": "1",
                                       "sType": "*",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1804"
+                                      "line": "1808"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1805",
+                                      "line": "1809",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -35107,7 +35107,7 @@
                                                               "slot": "1",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1805"
+                                                              "line": "1809"
                                                             }
                                                           ]
                                                         }
@@ -35138,13 +35138,13 @@
                                       "nodeTest": "*NA nQ{}element",
                                       "sType": "*NA nQ{}element",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1807"
+                                      "line": "1811"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1808",
+                                      "line": "1812",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -35172,7 +35172,7 @@
                                                               "nodeTest": "*NA nQ{}element",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1808"
+                                                              "line": "1812"
                                                             }
                                                           ]
                                                         }
@@ -35203,13 +35203,13 @@
                                       "nodeTest": "*NA nQ{}type",
                                       "sType": "*NA nQ{}type",
                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                      "line": "1810"
+                                      "line": "1814"
                                     },
                                     {
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1811",
+                                      "line": "1815",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -35237,7 +35237,7 @@
                                                               "nodeTest": "*NA nQ{}type",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1811"
+                                                              "line": "1815"
                                                             }
                                                           ]
                                                         }
@@ -35268,7 +35268,7 @@
                                       "bSlot": "4",
                                       "sType": "* ",
                                       "name": "Q{}src.syntax-error",
-                                      "line": "1814"
+                                      "line": "1818"
                                     }
                                   ]
                                 }
@@ -35277,7 +35277,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "1819",
+                              "line": "1823",
                               "mode": "Q{}src.link-attribute",
                               "bSlot": "1",
                               "C": [
@@ -35286,7 +35286,7 @@
                                   "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1819",
+                                  "line": "1823",
                                   "C": [
                                     {
                                       "N": "gVarRef",
@@ -35333,7 +35333,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1792",
+              "line": "1796",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation/ws:input[@message] | ws:operation/ws:output[@message] | ws:operation/ws:fault[@message] | soap:header[ancestor::ws:operation and @message]",
@@ -35369,7 +35369,7 @@
                 {
                   "N": "applyT",
                   "sType": "* ",
-                  "line": "1794",
+                  "line": "1798",
                   "mode": "Q{}src.link-attribute",
                   "role": "action",
                   "bSlot": "1",
@@ -35380,7 +35380,7 @@
                       "slot": "199",
                       "xpath": "$consolidated-wsdl/ws:message[@name = substring-after( current()/@message, ':' )]",
                       "loc": "xsl:apply-templates/@select",
-                      "line": "1794",
+                      "line": "1798",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -35488,7 +35488,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1792",
+              "line": "1796",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation/ws:input[@message] | ws:operation/ws:output[@message] | ws:operation/ws:fault[@message] | soap:header[ancestor::ws:operation and @message]",
@@ -35524,7 +35524,7 @@
                 {
                   "N": "applyT",
                   "sType": "* ",
-                  "line": "1794",
+                  "line": "1798",
                   "mode": "Q{}src.link-attribute",
                   "role": "action",
                   "bSlot": "1",
@@ -35535,7 +35535,7 @@
                       "slot": "199",
                       "xpath": "$consolidated-wsdl/ws:message[@name = substring-after( current()/@message, ':' )]",
                       "loc": "xsl:apply-templates/@select",
-                      "line": "1794",
+                      "line": "1798",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -35643,7 +35643,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1792",
+              "line": "1796",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation/ws:input[@message] | ws:operation/ws:output[@message] | ws:operation/ws:fault[@message] | soap:header[ancestor::ws:operation and @message]",
@@ -35679,7 +35679,7 @@
                 {
                   "N": "applyT",
                   "sType": "* ",
-                  "line": "1794",
+                  "line": "1798",
                   "mode": "Q{}src.link-attribute",
                   "role": "action",
                   "bSlot": "1",
@@ -35690,7 +35690,7 @@
                       "slot": "199",
                       "xpath": "$consolidated-wsdl/ws:message[@name = substring-after( current()/@message, ':' )]",
                       "loc": "xsl:apply-templates/@select",
-                      "line": "1794",
+                      "line": "1798",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -35798,7 +35798,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1792",
+              "line": "1796",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation/ws:input[@message] | ws:operation/ws:output[@message] | ws:operation/ws:fault[@message] | soap:header[ancestor::ws:operation and @message]",
@@ -35840,7 +35840,7 @@
                 {
                   "N": "applyT",
                   "sType": "* ",
-                  "line": "1794",
+                  "line": "1798",
                   "mode": "Q{}src.link-attribute",
                   "role": "action",
                   "bSlot": "1",
@@ -35851,7 +35851,7 @@
                       "slot": "199",
                       "xpath": "$consolidated-wsdl/ws:message[@name = substring-after( current()/@message, ':' )]",
                       "loc": "xsl:apply-templates/@select",
-                      "line": "1794",
+                      "line": "1798",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -35959,7 +35959,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1787",
+              "line": "1791",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation/ws:input[@message] | ws:operation/ws:output[@message] | ws:operation/ws:fault[@message] | soap:header[ancestor::ws:operation and @message]",
@@ -35995,7 +35995,7 @@
                 {
                   "N": "applyT",
                   "sType": "* ",
-                  "line": "1789",
+                  "line": "1793",
                   "mode": "Q{}src.link-attribute",
                   "role": "action",
                   "bSlot": "1",
@@ -36006,7 +36006,7 @@
                       "slot": "199",
                       "xpath": "$consolidated-wsdl/ws:message[@name = substring-after( current()/@message, ':' )]",
                       "loc": "xsl:apply-templates/@select",
-                      "line": "1789",
+                      "line": "1793",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -36114,7 +36114,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1787",
+              "line": "1791",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation/ws:input[@message] | ws:operation/ws:output[@message] | ws:operation/ws:fault[@message] | soap:header[ancestor::ws:operation and @message]",
@@ -36150,7 +36150,7 @@
                 {
                   "N": "applyT",
                   "sType": "* ",
-                  "line": "1789",
+                  "line": "1793",
                   "mode": "Q{}src.link-attribute",
                   "role": "action",
                   "bSlot": "1",
@@ -36161,7 +36161,7 @@
                       "slot": "199",
                       "xpath": "$consolidated-wsdl/ws:message[@name = substring-after( current()/@message, ':' )]",
                       "loc": "xsl:apply-templates/@select",
-                      "line": "1789",
+                      "line": "1793",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -36269,7 +36269,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1787",
+              "line": "1791",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation/ws:input[@message] | ws:operation/ws:output[@message] | ws:operation/ws:fault[@message] | soap:header[ancestor::ws:operation and @message]",
@@ -36305,7 +36305,7 @@
                 {
                   "N": "applyT",
                   "sType": "* ",
-                  "line": "1789",
+                  "line": "1793",
                   "mode": "Q{}src.link-attribute",
                   "role": "action",
                   "bSlot": "1",
@@ -36316,7 +36316,7 @@
                       "slot": "199",
                       "xpath": "$consolidated-wsdl/ws:message[@name = substring-after( current()/@message, ':' )]",
                       "loc": "xsl:apply-templates/@select",
-                      "line": "1789",
+                      "line": "1793",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -36424,7 +36424,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1787",
+              "line": "1791",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws:operation/ws:input[@message] | ws:operation/ws:output[@message] | ws:operation/ws:fault[@message] | soap:header[ancestor::ws:operation and @message]",
@@ -36466,7 +36466,7 @@
                 {
                   "N": "applyT",
                   "sType": "* ",
-                  "line": "1789",
+                  "line": "1793",
                   "mode": "Q{}src.link-attribute",
                   "role": "action",
                   "bSlot": "1",
@@ -36477,7 +36477,7 @@
                       "slot": "199",
                       "xpath": "$consolidated-wsdl/ws:message[@name = substring-after( current()/@message, ':' )]",
                       "loc": "xsl:apply-templates/@select",
-                      "line": "1789",
+                      "line": "1793",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -36585,7 +36585,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1780",
+              "line": "1784",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:interface/ws2:operation/ws2:input|ws2:interface/ws2:operation/ws2:output|ws2:interface/ws2:fault",
@@ -36623,7 +36623,7 @@
                   "var": "Q{}elem-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1781",
+                  "line": "1785",
                   "role": "action",
                   "C": [
                     {
@@ -36635,7 +36635,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1782",
+                          "line": "1786",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -36646,7 +36646,7 @@
                               "sType": "*NA nQ{}element",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1782"
+                              "line": "1786"
                             }
                           ]
                         }
@@ -36655,7 +36655,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1784",
+                      "line": "1788",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -36664,7 +36664,7 @@
                           "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}*",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1784",
+                          "line": "1788",
                           "C": [
                             {
                               "N": "gVarRef",
@@ -36707,7 +36707,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1780",
+              "line": "1784",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:interface/ws2:operation/ws2:input|ws2:interface/ws2:operation/ws2:output|ws2:interface/ws2:fault",
@@ -36745,7 +36745,7 @@
                   "var": "Q{}elem-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1781",
+                  "line": "1785",
                   "role": "action",
                   "C": [
                     {
@@ -36757,7 +36757,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1782",
+                          "line": "1786",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -36768,7 +36768,7 @@
                               "sType": "*NA nQ{}element",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1782"
+                              "line": "1786"
                             }
                           ]
                         }
@@ -36777,7 +36777,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1784",
+                      "line": "1788",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -36786,7 +36786,7 @@
                           "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}*",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1784",
+                          "line": "1788",
                           "C": [
                             {
                               "N": "gVarRef",
@@ -36829,7 +36829,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1780",
+              "line": "1784",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:interface/ws2:operation/ws2:input|ws2:interface/ws2:operation/ws2:output|ws2:interface/ws2:fault",
@@ -36857,7 +36857,7 @@
                   "var": "Q{}elem-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1781",
+                  "line": "1785",
                   "role": "action",
                   "C": [
                     {
@@ -36869,7 +36869,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1782",
+                          "line": "1786",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -36880,7 +36880,7 @@
                               "sType": "*NA nQ{}element",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1782"
+                              "line": "1786"
                             }
                           ]
                         }
@@ -36889,7 +36889,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1784",
+                      "line": "1788",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -36898,7 +36898,7 @@
                           "sType": "*NE nQ{http://www.w3.org/2001/XMLSchema}*",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                           "role": "select",
-                          "line": "1784",
+                          "line": "1788",
                           "C": [
                             {
                               "N": "gVarRef",
@@ -36941,7 +36941,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1772",
+              "line": "1776",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:binding/ws2:fault|ws2:interface/ws2:operation/ws2:infault|ws2:interface/ws2:operation/ws2:outfault",
@@ -36969,7 +36969,7 @@
                   "var": "Q{}operation-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1773",
+                  "line": "1777",
                   "role": "action",
                   "C": [
                     {
@@ -36981,7 +36981,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1774",
+                          "line": "1778",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -36992,7 +36992,7 @@
                               "sType": "*NA nQ{}ref",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1774"
+                              "line": "1778"
                             }
                           ]
                         }
@@ -37001,7 +37001,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1777",
+                      "line": "1781",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -37009,7 +37009,7 @@
                           "N": "docOrder",
                           "sType": "*NE nQ{http://www.w3.org/ns/wsdl}fault",
                           "role": "select",
-                          "line": "1777",
+                          "line": "1781",
                           "C": [
                             {
                               "N": "docOrder",
@@ -37086,7 +37086,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1772",
+              "line": "1776",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:binding/ws2:fault|ws2:interface/ws2:operation/ws2:infault|ws2:interface/ws2:operation/ws2:outfault",
@@ -37124,7 +37124,7 @@
                   "var": "Q{}operation-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1773",
+                  "line": "1777",
                   "role": "action",
                   "C": [
                     {
@@ -37136,7 +37136,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1774",
+                          "line": "1778",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -37147,7 +37147,7 @@
                               "sType": "*NA nQ{}ref",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1774"
+                              "line": "1778"
                             }
                           ]
                         }
@@ -37156,7 +37156,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1777",
+                      "line": "1781",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -37164,7 +37164,7 @@
                           "N": "docOrder",
                           "sType": "*NE nQ{http://www.w3.org/ns/wsdl}fault",
                           "role": "select",
-                          "line": "1777",
+                          "line": "1781",
                           "C": [
                             {
                               "N": "docOrder",
@@ -37241,7 +37241,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1772",
+              "line": "1776",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:binding/ws2:fault|ws2:interface/ws2:operation/ws2:infault|ws2:interface/ws2:operation/ws2:outfault",
@@ -37279,7 +37279,7 @@
                   "var": "Q{}operation-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1773",
+                  "line": "1777",
                   "role": "action",
                   "C": [
                     {
@@ -37291,7 +37291,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1774",
+                          "line": "1778",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -37302,7 +37302,7 @@
                               "sType": "*NA nQ{}ref",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1774"
+                              "line": "1778"
                             }
                           ]
                         }
@@ -37311,7 +37311,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1777",
+                      "line": "1781",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -37319,7 +37319,7 @@
                           "N": "docOrder",
                           "sType": "*NE nQ{http://www.w3.org/ns/wsdl}fault",
                           "role": "select",
-                          "line": "1777",
+                          "line": "1781",
                           "C": [
                             {
                               "N": "docOrder",
@@ -37396,7 +37396,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1764",
+              "line": "1768",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:binding/ws2:operation",
@@ -37425,7 +37425,7 @@
                   "var": "Q{}operation-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1765",
+                  "line": "1769",
                   "role": "action",
                   "C": [
                     {
@@ -37437,7 +37437,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1766",
+                          "line": "1770",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -37448,7 +37448,7 @@
                               "sType": "*NA nQ{}ref",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1766"
+                              "line": "1770"
                             }
                           ]
                         }
@@ -37457,7 +37457,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1769",
+                      "line": "1773",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -37465,7 +37465,7 @@
                           "N": "docOrder",
                           "sType": "*NE nQ{http://www.w3.org/ns/wsdl}operation",
                           "role": "select",
-                          "line": "1769",
+                          "line": "1773",
                           "C": [
                             {
                               "N": "docOrder",
@@ -37542,7 +37542,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1742",
+              "line": "1746",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*[local-name() = 'import' or local-name() = 'include'][@location or @schemaLocation]",
@@ -37613,20 +37613,20 @@
                   "N": "choose",
                   "sType": "? ",
                   "role": "action",
-                  "line": "1743",
+                  "line": "1747",
                   "C": [
                     {
                       "N": "gVarRef",
                       "name": "Q{}ENABLE-LINK",
                       "bSlot": "5",
                       "sType": "* ",
-                      "line": "1743"
+                      "line": "1747"
                     },
                     {
                       "N": "att",
                       "name": "href",
                       "sType": "1NA ",
-                      "line": "1744",
+                      "line": "1748",
                       "C": [
                         {
                           "N": "fn",
@@ -37651,7 +37651,7 @@
                                               "N": "valueOf",
                                               "sType": "1NT ",
                                               "flags": "l",
-                                              "line": "1745",
+                                              "line": "1749",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -37667,7 +37667,7 @@
                                                           "sType": "1AS",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1745",
+                                                          "line": "1749",
                                                           "C": [
                                                             {
                                                               "N": "str",
@@ -37740,7 +37740,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1885",
+              "line": "1889",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:extension | xsd:restriction",
@@ -37758,7 +37758,7 @@
                   "var": "Q{}xsd-local-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1886",
+                  "line": "1890",
                   "role": "action",
                   "C": [
                     {
@@ -37767,7 +37767,7 @@
                       "sType": "1AS",
                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                       "role": "select",
-                      "line": "1886",
+                      "line": "1890",
                       "C": [
                         {
                           "N": "fn",
@@ -37797,7 +37797,7 @@
                       "var": "Q{}xsd-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1887",
+                      "line": "1891",
                       "C": [
                         {
                           "N": "doc",
@@ -37809,7 +37809,7 @@
                               "N": "choose",
                               "sType": "?NT ",
                               "type": "item()*",
-                              "line": "1888",
+                              "line": "1892",
                               "C": [
                                 {
                                   "N": "varRef",
@@ -37817,13 +37817,13 @@
                                   "slot": "0",
                                   "sType": "*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1889"
+                                  "line": "1893"
                                 },
                                 {
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "1890",
+                                  "line": "1894",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -37851,7 +37851,7 @@
                                                           "slot": "0",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1890"
+                                                          "line": "1894"
                                                         }
                                                       ]
                                                     }
@@ -37881,7 +37881,7 @@
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "1893",
+                                  "line": "1897",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -37909,7 +37909,7 @@
                                                           "nodeTest": "*NA nQ{}type",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1893"
+                                                          "line": "1897"
                                                         }
                                                       ]
                                                     }
@@ -37943,14 +37943,14 @@
                           "var": "Q{}msg",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1897",
+                          "line": "1901",
                           "C": [
                             {
                               "N": "first",
                               "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1897",
+                              "line": "1901",
                               "C": [
                                 {
                                   "N": "filter",
@@ -37985,7 +37985,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "1898",
+                              "line": "1902",
                               "mode": "Q{}src.link-attribute",
                               "bSlot": "1",
                               "C": [
@@ -37996,7 +37996,7 @@
                                   "sType": "*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1898"
+                                  "line": "1902"
                                 }
                               ]
                             }
@@ -38018,7 +38018,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1885",
+              "line": "1889",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "xsd:extension | xsd:restriction",
@@ -38036,7 +38036,7 @@
                   "var": "Q{}xsd-local-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1886",
+                  "line": "1890",
                   "role": "action",
                   "C": [
                     {
@@ -38045,7 +38045,7 @@
                       "sType": "1AS",
                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                       "role": "select",
-                      "line": "1886",
+                      "line": "1890",
                       "C": [
                         {
                           "N": "fn",
@@ -38075,7 +38075,7 @@
                       "var": "Q{}xsd-name",
                       "slot": "1",
                       "sType": "* ",
-                      "line": "1887",
+                      "line": "1891",
                       "C": [
                         {
                           "N": "doc",
@@ -38087,7 +38087,7 @@
                               "N": "choose",
                               "sType": "?NT ",
                               "type": "item()*",
-                              "line": "1888",
+                              "line": "1892",
                               "C": [
                                 {
                                   "N": "varRef",
@@ -38095,13 +38095,13 @@
                                   "slot": "0",
                                   "sType": "*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                  "line": "1889"
+                                  "line": "1893"
                                 },
                                 {
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "1890",
+                                  "line": "1894",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -38129,7 +38129,7 @@
                                                           "slot": "0",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1890"
+                                                          "line": "1894"
                                                         }
                                                       ]
                                                     }
@@ -38159,7 +38159,7 @@
                                   "N": "valueOf",
                                   "flags": "l",
                                   "sType": "1NT ",
-                                  "line": "1893",
+                                  "line": "1897",
                                   "C": [
                                     {
                                       "N": "fn",
@@ -38187,7 +38187,7 @@
                                                           "nodeTest": "*NA nQ{}type",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1893"
+                                                          "line": "1897"
                                                         }
                                                       ]
                                                     }
@@ -38221,14 +38221,14 @@
                           "var": "Q{}msg",
                           "slot": "2",
                           "sType": "* ",
-                          "line": "1897",
+                          "line": "1901",
                           "C": [
                             {
                               "N": "first",
                               "sType": "?NE nQ{http://www.w3.org/2001/XMLSchema}*",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1897",
+                              "line": "1901",
                               "C": [
                                 {
                                   "N": "filter",
@@ -38263,7 +38263,7 @@
                             {
                               "N": "applyT",
                               "sType": "* ",
-                              "line": "1898",
+                              "line": "1902",
                               "mode": "Q{}src.link-attribute",
                               "bSlot": "1",
                               "C": [
@@ -38274,7 +38274,7 @@
                                   "sType": "*",
                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                   "role": "select",
-                                  "line": "1898"
+                                  "line": "1902"
                                 }
                               ]
                             }
@@ -38296,7 +38296,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1757",
+              "line": "1761",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:endpoint",
@@ -38315,7 +38315,7 @@
                   "var": "Q{}binding-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1758",
+                  "line": "1762",
                   "role": "action",
                   "C": [
                     {
@@ -38327,7 +38327,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1759",
+                          "line": "1763",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -38338,7 +38338,7 @@
                               "sType": "*NA nQ{}binding",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1759"
+                              "line": "1763"
                             }
                           ]
                         }
@@ -38347,7 +38347,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1762",
+                      "line": "1766",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -38355,7 +38355,7 @@
                           "N": "docOrder",
                           "sType": "*NE nQ{http://www.w3.org/ns/wsdl}binding",
                           "role": "select",
-                          "line": "1762",
+                          "line": "1766",
                           "C": [
                             {
                               "N": "docOrder",
@@ -38421,7 +38421,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1750",
+              "line": "1754",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:service|ws2:binding",
@@ -38439,7 +38439,7 @@
                   "var": "Q{}iface-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1751",
+                  "line": "1755",
                   "role": "action",
                   "C": [
                     {
@@ -38451,7 +38451,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1752",
+                          "line": "1756",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -38462,7 +38462,7 @@
                               "sType": "*NA nQ{}interface",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1752"
+                              "line": "1756"
                             }
                           ]
                         }
@@ -38471,7 +38471,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1755",
+                      "line": "1759",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -38479,7 +38479,7 @@
                           "N": "docOrder",
                           "sType": "*NE nQ{http://www.w3.org/ns/wsdl}interface",
                           "role": "select",
-                          "line": "1755",
+                          "line": "1759",
                           "C": [
                             {
                               "N": "docOrder",
@@ -38545,7 +38545,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1750",
+              "line": "1754",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "ws2:service|ws2:binding",
@@ -38563,7 +38563,7 @@
                   "var": "Q{}iface-name",
                   "slot": "0",
                   "sType": "* ",
-                  "line": "1751",
+                  "line": "1755",
                   "role": "action",
                   "C": [
                     {
@@ -38575,7 +38575,7 @@
                         {
                           "N": "applyT",
                           "sType": "* ",
-                          "line": "1752",
+                          "line": "1756",
                           "mode": "Q{}qname.normalized",
                           "bSlot": "2",
                           "C": [
@@ -38586,7 +38586,7 @@
                               "sType": "*NA nQ{}interface",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1752"
+                              "line": "1756"
                             }
                           ]
                         }
@@ -38595,7 +38595,7 @@
                     {
                       "N": "applyT",
                       "sType": "* ",
-                      "line": "1755",
+                      "line": "1759",
                       "mode": "Q{}src.link-attribute",
                       "bSlot": "1",
                       "C": [
@@ -38603,7 +38603,7 @@
                           "N": "docOrder",
                           "sType": "*NE nQ{http://www.w3.org/ns/wsdl}interface",
                           "role": "select",
-                          "line": "1755",
+                          "line": "1759",
                           "C": [
                             {
                               "N": "docOrder",
@@ -38669,7 +38669,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1749",
+              "line": "1753",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*",
@@ -38713,7 +38713,7 @@
               "flags": "s",
               "slots": "200",
               "baseUri": "file:///Users/dweber019/Documents/ProjectPrivate/backstage-plugins/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl",
-              "line": "1921",
+              "line": "1925",
               "module": "wsdl-viewer.xsl",
               "expand-text": "false",
               "match": "*",
@@ -38732,7 +38732,7 @@
                   "var": "Q{}current",
                   "slot": "1",
                   "sType": "* ",
-                  "line": "1923",
+                  "line": "1927",
                   "role": "action",
                   "C": [
                     {
@@ -38741,7 +38741,7 @@
                       "slot": "199",
                       "xpath": "current()",
                       "loc": "xsl:variable/@select",
-                      "line": "1923",
+                      "line": "1927",
                       "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                       "role": "select",
                       "BC": "true",
@@ -38760,7 +38760,7 @@
                       "N": "choose",
                       "sType": "* ",
                       "type": "item()*",
-                      "line": "1925",
+                      "line": "1929",
                       "C": [
                         {
                           "N": "gc10",
@@ -38769,7 +38769,7 @@
                           "card": "1:1",
                           "sType": "1AB",
                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                          "line": "1926",
+                          "line": "1930",
                           "C": [
                             {
                               "N": "fn",
@@ -38811,14 +38811,14 @@
                         {
                           "N": "forEach",
                           "sType": "* ",
-                          "line": "1934",
+                          "line": "1938",
                           "C": [
                             {
                               "N": "filter",
                               "sType": "*NN",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                               "role": "select",
-                              "line": "1934",
+                              "line": "1938",
                               "C": [
                                 {
                                   "N": "axis",
@@ -38843,7 +38843,7 @@
                             {
                               "N": "choose",
                               "sType": "? ",
-                              "line": "1935",
+                              "line": "1939",
                               "C": [
                                 {
                                   "N": "let",
@@ -38851,7 +38851,7 @@
                                   "slot": "199",
                                   "xpath": "not($current/parent::*[namespace::*[. = current()]])",
                                   "loc": "xsl:if/@test",
-                                  "line": "1935",
+                                  "line": "1939",
                                   "ns": "xml=~ xsl=~ =http://www.w3.org/1999/xhtml ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer",
                                   "BC": "true",
                                   "sType": "1AB",
@@ -38930,7 +38930,7 @@
                                   "sType": "1NE nQ{http://www.w3.org/1999/xhtml}div ",
                                   "nsuri": "http://www.w3.org/1999/xhtml",
                                   "namespaces": "=http://www.w3.org/1999/xhtml",
-                                  "line": "1936",
+                                  "line": "1940",
                                   "C": [
                                     {
                                       "N": "sequence",
@@ -38963,14 +38963,14 @@
                                         {
                                           "N": "choose",
                                           "sType": "? ",
-                                          "line": "1938",
+                                          "line": "1942",
                                           "C": [
                                             {
                                               "N": "fn",
                                               "name": "string-length",
                                               "sType": "1ADI",
                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                              "line": "1938",
+                                              "line": "1942",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -38998,7 +38998,7 @@
                                           "N": "valueOf",
                                           "flags": "l",
                                           "sType": "1NT ",
-                                          "line": "1939",
+                                          "line": "1943",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -39014,7 +39014,7 @@
                                                       "sType": "1AS",
                                                       "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                       "role": "select",
-                                                      "line": "1939",
+                                                      "line": "1943",
                                                       "C": [
                                                         {
                                                           "N": "fn",
@@ -39044,7 +39044,7 @@
                                           "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                                           "nsuri": "http://www.w3.org/1999/xhtml",
                                           "namespaces": "=http://www.w3.org/1999/xhtml",
-                                          "line": "1940",
+                                          "line": "1944",
                                           "C": [
                                             {
                                               "N": "sequence",
@@ -39067,7 +39067,7 @@
                                                   "N": "valueOf",
                                                   "flags": "d",
                                                   "sType": "1NT ",
-                                                  "line": "1941",
+                                                  "line": "1945",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -39083,7 +39083,7 @@
                                                               "sType": "1AS",
                                                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                               "role": "select",
-                                                              "line": "1941",
+                                                              "line": "1945",
                                                               "C": [
                                                                 {
                                                                   "N": "str",
@@ -39134,13 +39134,13 @@
                         {
                           "N": "choose",
                           "sType": "? ",
-                          "line": "1958",
+                          "line": "1962",
                           "C": [
                             {
                               "N": "or",
                               "sType": "1AB",
                               "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                              "line": "1958",
+                              "line": "1962",
                               "C": [
                                 {
                                   "N": "gc10",
@@ -39190,7 +39190,7 @@
                               "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                               "nsuri": "http://www.w3.org/1999/xhtml",
                               "namespaces": "=http://www.w3.org/1999/xhtml",
-                              "line": "1959",
+                              "line": "1963",
                               "C": [
                                 {
                                   "N": "sequence",
@@ -39223,7 +39223,7 @@
                                     {
                                       "N": "choose",
                                       "sType": "? ",
-                                      "line": "1961",
+                                      "line": "1965",
                                       "C": [
                                         {
                                           "N": "gc10",
@@ -39232,7 +39232,7 @@
                                           "card": "1:1",
                                           "sType": "1AB",
                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
-                                          "line": "1961",
+                                          "line": "1965",
                                           "C": [
                                             {
                                               "N": "fn",
@@ -39272,7 +39272,7 @@
                                       "N": "valueOf",
                                       "flags": "l",
                                       "sType": "1NT ",
-                                      "line": "1962",
+                                      "line": "1966",
                                       "C": [
                                         {
                                           "N": "fn",
@@ -39288,7 +39288,7 @@
                                                   "sType": "1AS",
                                                   "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                   "role": "select",
-                                                  "line": "1962",
+                                                  "line": "1966",
                                                   "C": [
                                                     {
                                                       "N": "fn",
@@ -39330,7 +39330,7 @@
                                       "sType": "1NE nQ{http://www.w3.org/1999/xhtml}span ",
                                       "nsuri": "http://www.w3.org/1999/xhtml",
                                       "namespaces": "=http://www.w3.org/1999/xhtml",
-                                      "line": "1964",
+                                      "line": "1968",
                                       "C": [
                                         {
                                           "N": "sequence",
@@ -39353,7 +39353,7 @@
                                               "N": "valueOf",
                                               "flags": "d",
                                               "sType": "1NT ",
-                                              "line": "1965",
+                                              "line": "1969",
                                               "C": [
                                                 {
                                                   "N": "fn",
@@ -39369,7 +39369,7 @@
                                                           "sType": "1AS",
                                                           "ns": "= xml=~ fn=~ xsl=~ ws=http://schemas.xmlsoap.org/wsdl/ ws2=http://www.w3.org/ns/wsdl xsd=http://www.w3.org/2001/XMLSchema soap=http://schemas.xmlsoap.org/wsdl/soap/ local=http://tomi.vanek.sk/xml/wsdl-viewer ",
                                                           "role": "select",
-                                                          "line": "1965",
+                                                          "line": "1969",
                                                           "C": [
                                                             {
                                                               "N": "str",
@@ -39440,5 +39440,5 @@
     { "N": "decimalFormat" },
     { "N": "strip", "C": [{ "N": "s", "test": "NE", "prec": "0" }] }
   ],
-  "Σ": "d5b7812c"
+  "Σ": "eecb1c0c"
 }

--- a/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl
+++ b/plugins/api-docs-module-wsdl-backend/wsdl-viewer.xsl
@@ -303,9 +303,13 @@ html&gt;body #rightColumn {
 */
 
 .page {
-	border-bottom: 3px dotted navy;
+	border-bottom: 3px dotted rgba(0, 0, 0, 0.87);
 	margin: 0;
 	padding: 10px 0 20px 0;
+}
+
+.theme-dark .page {
+    border-bottom: 3px dotted #fff;
 }
 
 .page:last-child {
@@ -324,12 +328,10 @@ html&gt;body #rightColumn {
 	font-weight: bold;
 	padding-bottom: .5em;
 	margin-right: 0;
-	color: darkblue;
 }
 
 .value {
 	margin-left: 147px;
-	color: darkblue;
 	padding-bottom: .5em;
 }
 
@@ -349,18 +351,16 @@ strong, strong a {
 
 a.local:link,
 a.local:visited {
-	color: blue; 
+    color: #1F5493;
 	margin-left: 10px;
-	border-bottom: 1px dotted blue;
-	text-decoration: none;
-	font-style: italic;
 }
 
 a.local:hover {
-	background-color: gainsboro; 
-	color: darkblue;
-	padding-bottom: 1px;
-	border-bottom: 1px solid darkblue;
+    text-decoration: underline;
+}
+
+.theme-dark a.local {
+    color: #9CC9FF;
 }
 
 a.target:link,
@@ -380,9 +380,13 @@ a.target:hover
 
 .box {
 	padding: 6px;
-	color: black;
-	background-color: gainsboro;
-	border: 1px solid gray;
+    background-color: #F8F8F8;
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.theme-dark .box {
+    color: rgba(0, 0, 0, 0.87);
 }
 
 .shadow {

--- a/plugins/api-docs-module-wsdl/src/components/WsdlDefinitionWidget/WsdlDefinition.tsx
+++ b/plugins/api-docs-module-wsdl/src/components/WsdlDefinitionWidget/WsdlDefinition.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { Alert } from '@material-ui/lab';
 import { Progress } from '@backstage/core-components';
-import { useApi } from '@backstage/core-plugin-api';
+import { appThemeApiRef, useApi } from '@backstage/core-plugin-api';
 import { apiDocsModuleWsdlApiRef } from '../../api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { stringifyEntityRef } from '@backstage/catalog-model';
@@ -14,6 +14,7 @@ export type WsdlDefinitionProps = {
 export const WsdlDefinition = ({ definition }: WsdlDefinitionProps) => {
   const apiDocsModuleWsdlDocApi = useApi(apiDocsModuleWsdlApiRef);
   const { entity } = useEntity();
+  const appThemeApi = useApi(appThemeApiRef);
   const result = useAsync(() => {
     return apiDocsModuleWsdlDocApi.convert(stringifyEntityRef(entity));
   }, [definition]);
@@ -26,5 +27,10 @@ export const WsdlDefinition = ({ definition }: WsdlDefinitionProps) => {
     return <Alert severity="error">{result?.error?.message}</Alert>;
   }
 
-  return <div dangerouslySetInnerHTML={{ __html: result.value || '' }} />;
+  return (
+    <div
+      className={`theme-${appThemeApi.getActiveThemeId()}`}
+      dangerouslySetInnerHTML={{ __html: result.value || '' }}
+    />
+  );
 };


### PR DESCRIPTION
Will fix #5 

Light mode look now like this
![Screen Shot 2024-03-07 at 22 15 21 PM](https://github.com/dweber019/backstage-plugins/assets/1021324/4950c82b-f1fd-4864-9cce-9e9a2f934afc)
![Screen Shot 2024-03-07 at 22 15 38 PM](https://github.com/dweber019/backstage-plugins/assets/1021324/619cc560-c543-4df8-bb26-4472a072e40d)

And dark mode like
![Screen Shot 2024-03-07 at 22 16 29 PM](https://github.com/dweber019/backstage-plugins/assets/1021324/857ad110-4622-48c1-87c1-71b3daf46121)
![Screen Shot 2024-03-07 at 22 16 42 PM](https://github.com/dweber019/backstage-plugins/assets/1021324/4d13b2e4-70b9-4c20-9590-c646d833a5ae)
![Screen Shot 2024-03-07 at 22 16 53 PM](https://github.com/dweber019/backstage-plugins/assets/1021324/1929e22d-a87a-4070-92bb-ef204b5c11a2)
