### PR TITLE
feat(wsdl): backend auth support

### DIFF
--- a/.changeset/sharp-kiwis-speak.md
+++ b/.changeset/sharp-kiwis-speak.md
@@ -1,5 +1,5 @@
 ---
-'@dweber019/backstage-plugin-api-docs-module-wsdl-backend': minor
+'@dweber019/backstage-plugin-api-docs-module-wsdl-backend': patch
 ---
 
 added tokenManager for authenticated catalogClient calls

--- a/.changeset/sharp-kiwis-speak.md
+++ b/.changeset/sharp-kiwis-speak.md
@@ -1,0 +1,5 @@
+---
+'@dweber019/backstage-plugin-api-docs-module-wsdl-backend': minor
+---
+
+added tokenManager for authenticated catalogClient calls

--- a/packages/backend/src/plugins/apiDocsModuleWsdl.ts
+++ b/packages/backend/src/plugins/apiDocsModuleWsdl.ts
@@ -5,5 +5,5 @@ import { PluginEnvironment } from '../types';
 export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
-  return await createRouter({ logger: env.logger, discovery: env.discovery });
+  return await createRouter({ logger: env.logger, discovery: env.discovery, tokenManager: env.tokenManager });
 }

--- a/plugins/api-docs-module-wsdl-backend/src/plugin.ts
+++ b/plugins/api-docs-module-wsdl-backend/src/plugin.ts
@@ -17,12 +17,14 @@ export const apiDocsModuleWsdlPlugin = createBackendPlugin({
         logger: coreServices.logger,
         httpRouter: coreServices.httpRouter,
         discovery: coreServices.discovery,
+        tokenManager: coreServices.tokenManager,
       },
-      async init({ logger, httpRouter, discovery }) {
+      async init({ logger, httpRouter, discovery, tokenManager }) {
         httpRouter.use(
           await createRouter({
             logger: loggerToWinstonLogger(logger),
             discovery,
+            tokenManager,
           }),
         );
       },

--- a/plugins/api-docs-module-wsdl-backend/src/service/router.ts
+++ b/plugins/api-docs-module-wsdl-backend/src/service/router.ts
@@ -3,7 +3,7 @@ import Router from 'express-promise-router';
 import fetch from 'cross-fetch';
 import { Logger } from 'winston';
 import { CatalogClient } from '@backstage/catalog-client';
-import {PluginEndpointDiscovery, TokenManager} from '@backstage/backend-common';
+import { PluginEndpointDiscovery, TokenManager } from '@backstage/backend-common';
 import { ApiEntity } from '@backstage/catalog-model';
 // @ts-ignore
 import SaxonJS from 'saxon-js';

--- a/plugins/api-docs-module-wsdl-backend/src/service/standaloneServer.ts
+++ b/plugins/api-docs-module-wsdl-backend/src/service/standaloneServer.ts
@@ -1,7 +1,8 @@
 import {
   createServiceBuilder,
   HostDiscovery,
-  loadBackendConfig, ServerTokenManager,
+  loadBackendConfig,
+  ServerTokenManager,
 } from '@backstage/backend-common';
 import { Server } from 'http';
 import { Logger } from 'winston';

--- a/plugins/api-docs-module-wsdl-backend/src/service/standaloneServer.ts
+++ b/plugins/api-docs-module-wsdl-backend/src/service/standaloneServer.ts
@@ -1,7 +1,7 @@
 import {
   createServiceBuilder,
   HostDiscovery,
-  loadBackendConfig,
+  loadBackendConfig, ServerTokenManager,
 } from '@backstage/backend-common';
 import { Server } from 'http';
 import { Logger } from 'winston';
@@ -24,6 +24,7 @@ export async function startStandaloneServer(
   const router = await createRouter({
     logger,
     discovery: HostDiscovery.fromConfig(config),
+    tokenManager: ServerTokenManager.noop(),
   });
 
   let service = createServiceBuilder(module)


### PR DESCRIPTION
Hi @dweber019

we are using plugin-2-plugin-auth in our backstage instance. Since the plugin uses the catalogApi we are running into http 401 status codes, because the catalogApi doenst use the auth from the user.

Therefore i added the tokenManger to extract the token of the current user and use the authentication.

Cheers 
Olli