### PR TITLE
endoflife: Fixed error for products that share the same cycles

### DIFF
--- a/.changeset/new-windows-turn.md
+++ b/.changeset/new-windows-turn.md
@@ -1,0 +1,5 @@
+---
+'@dweber019/backstage-plugin-endoflife': patch
+---
+
+Fixed error for products that share the same cycles

--- a/plugins/endoflife/src/components/EntityEndOfLifeCard/helper.test.ts
+++ b/plugins/endoflife/src/components/EntityEndOfLifeCard/helper.test.ts
@@ -117,7 +117,7 @@ describe('Helper', () => {
       ]);
 
       expect(groups.length).toBe(3);
-      expect(groups[0].id).toBe('4');
+      expect(groups[0].id).toBe('rhel-4');
       expect((groups[0].content as HTMLElement).innerHTML).toContain('rhel 4');
     });
   });

--- a/plugins/endoflife/src/components/EntityEndOfLifeCard/helper.ts
+++ b/plugins/endoflife/src/components/EntityEndOfLifeCard/helper.ts
@@ -67,7 +67,7 @@ export const calculateTimelineGroups = (
     `;
 
     return {
-      id: cycleItem.cycle,
+      id: `${cycleItem.product}-${cycleItem.cycle}`,
       content,
     };
   });
@@ -97,7 +97,7 @@ export const calculateTimelineItems = (
           id: `${index}-support`,
           content: 'Support',
           title: `Support (${cycleItem.releaseDate} - ${cycleItem.support})`,
-          group: cycleItem.cycle,
+          group: `${cycleItem.product}-${cycleItem.cycle}`,
           start: cycleItem.releaseDate,
           end: cycleItem.support as string,
           className: getDateClass(cycleItem.support as string),
@@ -109,7 +109,7 @@ export const calculateTimelineItems = (
           id: `${index}-support`,
           content: 'Support',
           title: `Support (${cycleItem.releaseDate} - end date not defined)`,
-          group: cycleItem.cycle,
+          group: `${cycleItem.product}-${cycleItem.cycle}`,
           start: cycleItem.releaseDate,
           end: dateNow.toISO(),
           className: 'dateOk',
@@ -129,7 +129,7 @@ export const calculateTimelineItems = (
           id: `${index}-eol`,
           content: 'EOL',
           title: `EOL (${startDate} - ${cycleItem.eol})`,
-          group: cycleItem.cycle,
+          group: `${cycleItem.product}-${cycleItem.cycle}`,
           start: startDate,
           end: cycleItem.eol as string,
           className: getDateClass(cycleItem.eol as string),
@@ -147,7 +147,7 @@ export const calculateTimelineItems = (
           id: `${index}-eol`,
           content: 'EOL',
           title: `EOL (${startDate} - end date not defined)`,
-          group: cycleItem.cycle,
+          group: `${cycleItem.product}-${cycleItem.cycle}`,
           start: startDate,
           end: dateNow.toISO(),
           className: 'dateOk',
@@ -167,7 +167,7 @@ export const calculateTimelineItems = (
           id: `${index}-extendedSupport`,
           content: 'Extended support',
           title: `Extended support (${startDate} - ${cycleItem.extendedSupport})`,
-          group: cycleItem.cycle,
+          group: `${cycleItem.product}-${cycleItem.cycle}`,
           start: startDate,
           end: cycleItem.extendedSupport as string,
           className: getDateClass(cycleItem.extendedSupport as string),
@@ -185,7 +185,7 @@ export const calculateTimelineItems = (
           id: `${index}-extendedSupport`,
           content: 'Extended support',
           title: `Extended support (${startDate} - end date not defined)`,
-          group: cycleItem.cycle,
+          group: `${cycleItem.product}-${cycleItem.cycle}`,
           start: startDate,
           end: dateNow.toISO(),
           className: 'dateOk',
@@ -206,7 +206,7 @@ export const calculateTimelineItems = (
           title: `Support ${
             isBooleanAnd(cycleItem.discontinued, true) ? 'discontinued ' : ''
           }(${cycleItem.releaseDate} - ${endDateTitle})`,
-          group: cycleItem.cycle,
+          group: `${cycleItem.product}-${cycleItem.cycle}`,
           start: cycleItem.releaseDate,
           end: endDate,
           className: isBooleanAnd(cycleItem.discontinued, true)


### PR DESCRIPTION
The EntityEndOfLifeCard will error when multiple products are listed that share the same cycle. As an example, adding the annotation `'endoflife.date/products': 'oracle-jdk,redhat-jboss-eap@7'` will trigger that error on rendering the card.

Error log
```
Cannot add item: item with id 7 already exists
    at DataSet._addItem (webpack-internal:///../../node_modules/vis-timeline/standalone/esm/vis-timeline-graph2d.js:23660:15)
    at DataSet.add (webpack-internal:///../../node_modules/vis-timeline/standalone/esm/vis-timeline-graph2d.js:22979:21)
    at new DataSet (webpack-internal:///../../node_modules/vis-timeline/standalone/esm/vis-timeline-graph2d.js:22897:14)
    at Timeline.setGroups (webpack-internal:///../../node_modules/vis-timeline/standalone/esm/vis-timeline-graph2d.js:42822:46)
    at new Timeline (webpack-internal:///../../node_modules/vis-timeline/standalone/esm/vis-timeline-graph2d.js:42708:13)
    at eval (webpack-internal:///../../node_modules/@dweber019/backstage-plugin-endoflife/dist/esm/index-666b849a.esm.js:366:27)
    at eval (webpack-internal:///../../node_modules/@dweber019/backstage-plugin-endoflife/dist/esm/index-666b849a.esm.js:382:5)
    at commitHookEffectListMount (webpack-internal:///../../node_modules/react-dom/cjs/react-dom.development.js:23145:26)
    at commitPassiveMountOnFiber (webpack-internal:///../../node_modules/react-dom/cjs/react-dom.development.js:24921:13)
    at commitPassiveMountEffects_complete (webpack-internal:///../../node_modules/react-dom/cjs/react-dom.development.js:24886:9)
```

PR includes the fix and an accompanying test 