### PR TITLE
Eliminate duplicate values in enum for custom relations

### DIFF
--- a/.changeset/beige-countries-itch.md
+++ b/.changeset/beige-countries-itch.md
@@ -1,0 +1,5 @@
+---
+'@dweber019/backstage-plugin-relations-backend': patch
+---
+
+Ensure the multiple custom relations for a single kind do not result in an invalid JSON schema

--- a/plugins/relations-backend/src/processor/processorConfig.test.ts
+++ b/plugins/relations-backend/src/processor/processorConfig.test.ts
@@ -45,6 +45,53 @@ describe('processorConfig', () => {
     });
   });
 
+  test('should allow for multiple sourceKind mappings without creating an invalid schema', async () => {
+    const config = new ConfigReader({
+      relationsProcessor: {
+        relations: [
+          {
+            sourceKind: 'Component',
+            attribute: 'owner',
+            pairs: [
+              {
+                incoming: 'ownerOf',
+                outgoing: 'ownerBy',
+              },
+            ],
+          },
+          {
+            sourceKind: 'component',
+            attribute: 'test',
+            multi: true,
+            pairs: [
+              {
+                incoming: 'testOf',
+                outgoing: 'testBy',
+              },
+            ],
+          },
+          {
+            sourceKind: 'group',
+            attribute: 'leader',
+            pairs: [
+              {
+                incoming: 'leaderOf',
+                outgoing: 'leadBy',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const processorConfig = new ProcessorConfig(config);
+    const schema = processorConfig.getSchema();
+
+    expect(schema.allOf[1].properties?.kind.enum).toHaveLength(2);
+    expect(schema.allOf[1].properties?.kind.enum).toContain('component');
+    expect(schema.allOf[1].properties?.kind.enum).toContain('group');
+  });
+
   test('should return only test relation', async () => {
     const config = new ConfigReader({
       relationsProcessor: {

--- a/plugins/relations-backend/src/processor/processorConfig.ts
+++ b/plugins/relations-backend/src/processor/processorConfig.ts
@@ -35,7 +35,8 @@ export class ProcessorConfig {
   }
 
   getSchema() {
-    const finalSchema = relationV1alpha1Schema;
+    // since we are modifying the schema, we need to deep clone it first
+    const finalSchema = JSON.parse(JSON.stringify(relationV1alpha1Schema));
     this.relations.forEach(relation => {
       if (relation.multi) {
         // @ts-ignore

--- a/plugins/relations-backend/src/processor/processorConfig.ts
+++ b/plugins/relations-backend/src/processor/processorConfig.ts
@@ -53,9 +53,13 @@ export class ProcessorConfig {
       }
     });
     // @ts-ignore
-    finalSchema.allOf[1].properties.kind.enum = this.relations.map(relation =>
-      relation.sourceKind.toLocaleLowerCase(),
-    );
+    finalSchema.allOf[1].properties.kind.enum = [
+      // we utilize a Set here to avoid duplicate entries in the enum if there are multiple
+      // relations with the same sourceKind
+      ...new Set(
+        this.relations.map(relation => relation.sourceKind.toLocaleLowerCase()),
+      ),
+    ];
     return finalSchema;
   }
 


### PR DESCRIPTION
Previously, if the relations config specifies multiple custom relationships for the same `sourceKind`, the resulting JSON schema would have duplicate `enum` values which would result in the validation failing with an exception. This change uses a `Set` to ensure the enum values are unique.