### PR TITLE
feat: format API definition for readability

### DIFF
--- a/.changeset/short-eagles-lay.md
+++ b/.changeset/short-eagles-lay.md
@@ -1,0 +1,5 @@
+---
+'@dweber019/backstage-plugin-api-docs-spectral-linter': minor
+---
+
+Ensure API definition is formatted for readability

--- a/plugins/api-docs-spectral-linter/dev/index.tsx
+++ b/plugins/api-docs-spectral-linter/dev/index.tsx
@@ -19,6 +19,9 @@ import openapiBaloiseApiEntity from './openapi-baloise-example-api.yaml';
 // @ts-ignore
 import openapiOwaspApiEntity from './openapi-owasp-example-api.yaml';
 
+// @ts-ignore
+import openapiNonPrettyPrintedApiEntity from './openapi-non-pretty-printed-example-api.yaml';
+
 const mockConfig = new MockConfigApi({
   spectralLinter: {
     openApiRulesetUrl:
@@ -79,5 +82,14 @@ createDevApp()
     ),
     title: 'Open API - OWASP',
     path: '/open-api-owasp',
+  })
+  .addPage({
+    element: (
+      <EntityProvider entity={openapiNonPrettyPrintedApiEntity as any as Entity}>
+        <EntityApiDocsSpectralLinterContent />
+      </EntityProvider>
+    ),
+    title: 'Open API - Non Pretty Printed',
+    path: '/open-api-non-pretty-printed',
   })
   .render();

--- a/plugins/api-docs-spectral-linter/dev/openapi-non-pretty-printed-example-api.yaml
+++ b/plugins/api-docs-spectral-linter/dev/openapi-non-pretty-printed-example-api.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: petstore
+  description: The petstore API
+  tags:
+    - store
+    - rest
+spec:
+  type: openapi
+  lifecycle: experimental
+  owner: team-c
+  definition: '{"openapi":"3.0.0","info":{"version":"1.0.0","title":"Swagger Petstore","license":{"name":"MIT"}},"servers":[{"url":"http://petstore.swagger.io/v1"}],"paths":{"/pets":{"get":{"summary":"List all pets","operationId":"listPets","tags":["pets"],"parameters":[{"name":"limit","in":"query","description":"How many items to return at one time (max 100)","required":false,"schema":{"type":"integer","format":"int32"}}],"responses":{"200":{"description":"A paged array of pets","headers":{"x-next":{"description":"A link to the next page of responses","schema":{"type":"string"}}},"content":{"application/json":{"schema":{"$ref":"#/components/schemas/Pets"}}}},"default":{"description":"unexpected error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Error"}}}}}},"post":{"summary":"Create a pet","operationId":"createPets","tags":["pets"],"responses":{"201":{"description":"Null response"},"default":{"description":"unexpected error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Error"}}}}}}},"/pets/{petId}":{"get":{"summary":"Info for a specific pet","operationId":"showPetById","tags":["pets"],"parameters":[{"name":"petId","in":"path","required":true,"description":"The id of the pet to retrieve","schema":{"type":"string"}}],"responses":{"200":{"description":"Expected response to a valid request","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Pet"}}}},"default":{"description":"unexpected error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Error"}}}}}}}},"components":{"schemas":{"Pet":{"type":"object","required":["id","name"],"properties":{"id":{"type":"integer","format":"int64"},"name":{"type":"string"},"tag":{"type":"string"}}},"Pets":{"type":"array","items":{"$ref":"#/components/schemas/Pet"}},"Error":{"type":"object","required":["code","message"],"properties":{"code":{"type":"integer","format":"int32"},"message":{"type":"string"}}}}}}'

--- a/plugins/api-docs-spectral-linter/src/api/LinterClient.ts
+++ b/plugins/api-docs-spectral-linter/src/api/LinterClient.ts
@@ -88,7 +88,10 @@ export class LinterClient implements LinterApi {
       fetch,
     });
     spectral.setRuleset(ruleSet);
-    const spectralResult = await spectral.run(content);
+
+    const formattedContent = countLines(content) === 1 ? prettyPrint(content) : content;
+
+    const spectralResult = await spectral.run(formattedContent);
 
     return {
       rulesetUrl: ruleSetToDownload,
@@ -104,7 +107,8 @@ export class LinterClient implements LinterApi {
           path: diagnosticItem.path.map(item => item.toString()),
           code: diagnosticItem.code,
           ruleDocumentationUrl: ruleDocumentationUrl(spectral, diagnosticItem.code),
-          ruleDescription: ruleDescription(spectral, diagnosticItem.code)
+          ruleDescription: ruleDescription(spectral, diagnosticItem.code),
+          definition: formattedContent
         })),
     };
   }
@@ -133,4 +137,12 @@ function ruleDocumentationUrl(spectral: Spectral, code: string | number): string
 
 function ruleDescription(spectral: Spectral, code: string | number): string | undefined {
   return spectral.ruleset?.rules[code].description || undefined
+}
+
+function countLines(str: string): number {
+  return str.split('\n').length;
+}
+
+function prettyPrint(str: string): string {
+  return JSON.stringify(JSON.parse(str), null, 2);
 }

--- a/plugins/api-docs-spectral-linter/src/api/types.ts
+++ b/plugins/api-docs-spectral-linter/src/api/types.ts
@@ -49,6 +49,11 @@ export type LinterResultData = {
    * Rule set code
    */
   code?: string | number;
+
+  /**
+   * The processed api definition
+   */
+  definition: string;
 };
 
 export type LinterResult = {

--- a/plugins/api-docs-spectral-linter/src/api/types.ts
+++ b/plugins/api-docs-spectral-linter/src/api/types.ts
@@ -51,7 +51,7 @@ export type LinterResultData = {
   code?: string | number;
 
   /**
-   * The processed api definition
+   * The formatted api definition
    */
   definition: string;
 };

--- a/plugins/api-docs-spectral-linter/src/components/EntityApiDocsSpectralLinterContent/EntityApiDocsSpectralLinterContent.tsx
+++ b/plugins/api-docs-spectral-linter/src/components/EntityApiDocsSpectralLinterContent/EntityApiDocsSpectralLinterContent.tsx
@@ -91,7 +91,7 @@ export const EntityApiDocsSpectralLinterContent = () => {
     textArray.push(`... line ${endLine + 1} in source`);
 
     if (isPrettyPrinted) {
-      textArray.unshift('# To Notice: The API definition has been pretty printed for readability.\n# The line numbers will not match the actual definition unless that is exposed properly formatted.')
+      textArray.unshift('# Notice: The API definition has been pretty printed for readability.\n# The line numbers will not match the actual definition.')
     }
     return textArray.join('\n');
   };

--- a/plugins/api-docs-spectral-linter/src/components/EntityApiDocsSpectralLinterContent/EntityApiDocsSpectralLinterContent.tsx
+++ b/plugins/api-docs-spectral-linter/src/components/EntityApiDocsSpectralLinterContent/EntityApiDocsSpectralLinterContent.tsx
@@ -79,6 +79,7 @@ export const EntityApiDocsSpectralLinterContent = () => {
     startLine: number,
     endLine: number,
     path: string,
+    isPrettyPrinted: boolean
   ) => {
     const textArray = text.split('\n');
     textArray.splice(0, startLine);
@@ -88,6 +89,10 @@ export const EntityApiDocsSpectralLinterContent = () => {
     );
     textArray.unshift(`... line ${startLine + 1} in source under path ${path}`);
     textArray.push(`... line ${endLine + 1} in source`);
+
+    if (isPrettyPrinted) {
+      textArray.unshift('# To Notice: The API definition has been pretty printed for readability.\n# The line numbers will not match the actual definition unless that is exposed properly formatted.')
+    }
     return textArray.join('\n');
   };
 
@@ -143,10 +148,11 @@ export const EntityApiDocsSpectralLinterContent = () => {
                         <MarkdownContent content={ ruleResult.ruleDescription || "" } />
                         <CodeSnippet
                           text={previewContent(
-                            entity.spec.definition,
+                            ruleResult.definition,
                             ruleResult.linePosition.start,
                             ruleResult.linePosition.end,
                             ruleResult.path?.join(' / ') || 'unknown',
+                            entity.spec.definition !== ruleResult.definition
                           )}
                           language="yaml"
                           customStyle={{


### PR DESCRIPTION
Hello again @dweber019!

This is more to trigger a discussion if you would like to support this use case. The code probably deserves some improvement but I would love to get your feedback in the general direction. 🙂 👍 

The context: 

When using `$text` placeholders for API entities targeting autogenerated OpenAPI specs, like the ones generated by [spring-boot-open-api](https://springdoc.org/) default behaviour, the output is not very readable (and breaks the layout).

<img width="1499" alt="Backstage" src="https://github.com/dweber019/backstage-plugins/assets/70795/bf779684-12fd-4560-8baf-99a3b9038ead">

The change proposed in the PR checks if the definition is a one-liner, if so then will assume it is not formatted and will pretty print it before processing.

Thanks in advance 🙏 