### PR TITLE
Fix typo in MissingEntityPage header

### DIFF
--- a/plugins/missing-entity/src/components/MissingEntityPage/MissingEntityPage.tsx
+++ b/plugins/missing-entity/src/components/MissingEntityPage/MissingEntityPage.tsx
@@ -49,7 +49,7 @@ export const MissingEntityPage = () => {
     <Page themeId="tool">
       <Header
         title="Missing entity"
-        subtitle="All enitities which are proccessed"
+        subtitle="All entities which are proccessed"
       />
       <Content>
         {error && <Alert severity="error">{error.message}</Alert>}


### PR DESCRIPTION
Fix a typo in the MissingEntityPage header (`enitities` -> `entities`).

I assume no changeset is needed for this, happy to generate it if needed.