### PR TITLE
chore: updating docs mitigating deprecated yarn arg order

### DIFF
--- a/plugins/accentuate-backend/README.md
+++ b/plugins/accentuate-backend/README.md
@@ -13,7 +13,7 @@ First we need to add the `@dweber019/backstage-plugin-accentuate-backend` packag
 
 ```sh
 # From your Backstage root directory
-yarn add --cwd packages/backend @dweber019/backstage-plugin-accentuate-backend
+yarn --cwd packages/backend add @dweber019/backstage-plugin-accentuate-backend
 ```
 
 Then we open the file named `packages/backend/src/plugins/catalog.ts`, and extend it with:

--- a/plugins/api-docs-module-wsdl-backend/README.md
+++ b/plugins/api-docs-module-wsdl-backend/README.md
@@ -5,7 +5,7 @@ Backend for the `@dweber019/backstage-plugin-api-docs-module-wsdl` frontend plug
 ## Setup
 
 ```
-yarn add --cwd packages/backend @dweber019/backstage-plugin-api-docs-module-wsdl-backend
+yarn --cwd packages/backend add @dweber019/backstage-plugin-api-docs-module-wsdl-backend
 ```
 
 Then integrate the plugin using the following default setup for `src/plugins/apiDocsModuleWsdl.ts`:

--- a/plugins/api-docs-module-wsdl/README.md
+++ b/plugins/api-docs-module-wsdl/README.md
@@ -6,7 +6,7 @@ You need to install the backend plugin too.
 ## Setup
 
 ```
-yarn add --cwd packages/app @dweber019/backstage-plugin-api-docs-module-wsdl
+yarn --cwd packages/app add @dweber019/backstage-plugin-api-docs-module-wsdl
 ```
 
 ### Add the wsdlDocsApiWidget to your apis

--- a/plugins/endoflife-backend/README.md
+++ b/plugins/endoflife-backend/README.md
@@ -14,7 +14,7 @@ First we need to add the `@dweber019/backstage-plugin-endoflife-backend` package
 
 ```sh
 # From your Backstage root directory
-yarn add --cwd packages/backend @dweber019/backstage-plugin-endoflife-backend
+yarn --cwd packages/backend add @dweber019/backstage-plugin-endoflife-backend
 ```
 
 Then we will create a new file named `packages/backend/src/plugins/endoflife.ts`, and add the following to it:

--- a/plugins/relations-backend/README.md
+++ b/plugins/relations-backend/README.md
@@ -15,7 +15,7 @@ First we need to add the `@dweber019/backstage-plugin-relations-backend` package
 
 ```sh
 # From your Backstage root directory
-yarn add --cwd packages/backend @dweber019/backstage-plugin-relations-backend
+yarn --cwd packages/backend add @dweber019/backstage-plugin-relations-backend
 ```
 
 Then we open the file named `packages/backend/src/plugins/catalog.ts`, and extend it with:


### PR DESCRIPTION
`yarn {command} --cwd {path}` fails, need to order args like `yarn --cwd {path} {command}`

<img width="1393" alt="Screenshot 2024-10-03 at 9 37 50 AM" src="https://github.com/user-attachments/assets/36ad6f24-de1d-4d1a-a9be-811b212b91bf">
