### PR TITLE
feat: Enable configuration of custom End of Life base Url

### DIFF
--- a/plugins/endoflife/README.md
+++ b/plugins/endoflife/README.md
@@ -155,6 +155,15 @@ endOfLife:
     You can use markdown if you like
 ```
 
+### Base Url
+
+If you're hosting a local End of Life instance, configure the base url to your service in the `app-config.yaml`
+
+```yaml
+endOfLife:
+  baseUrl: https://endoflife.mycompany.com
+```
+
 ## Troubleshooting
 
 ### Behavior 'endoflife.date/products': angular

--- a/plugins/endoflife/config.d.ts
+++ b/plugins/endoflife/config.d.ts
@@ -5,5 +5,12 @@ export interface Config {
      * @visibility frontend
      */
     helpText?: string;
+    /**
+     * Url of the end-of-life service
+     * @visibility frontend
+     *
+     * @default https://endoflife.date
+     */
+    baseUrl? string;
   };
 }

--- a/plugins/endoflife/src/plugin.ts
+++ b/plugins/endoflife/src/plugin.ts
@@ -5,6 +5,7 @@ import {
   discoveryApiRef,
   fetchApiRef,
   identityApiRef,
+  configApiRef,
 } from '@backstage/core-plugin-api';
 import { rootRouteRef } from './routes';
 import { endOfLifeApiRef, EndOfLifeClient } from './api';
@@ -19,10 +20,11 @@ export const endOfLifePlugin = createPlugin({
         discoveryApi: discoveryApiRef,
         fetchApi: fetchApiRef,
         identityApi: identityApiRef,
+        configApi: configApiRef,
       },
-      factory({ discoveryApi, fetchApi, identityApi }) {
+      factory({ discoveryApi, fetchApi, identityApi, configApi }) {
         return new EndOfLifeClient({
-          baseUrl: 'https://endoflife.date',
+          baseUrl: configApi.getOptionalString('endOfLife.baseUrl') ?? 'https://endoflife.date',
           discoveryApi,
           fetchApi,
           identityApi,


### PR DESCRIPTION
Some companies are hosting there own End of Life service to track their internal developments.

This PR introduces a new configuration key allowing to customize the base URL to the End of Life service.